### PR TITLE
Simple Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+
+sudo: false
+
+addons:
+    apt:
+        sources:
+            - hvr-ghc
+        packages:
+            - ghc-7.10.3
+            - happy-1.19.3
+            - alex-3.1.4
+            - cabal-install-1.22
+
+before_install:
+    - grep '\(MemTotal\|SwapTotal\)' /proc/meminfo
+    - git show | head -1  # (for matching against commit hash given on the travis log web page)
+    - export PATH=/opt/ghc/7.10.3/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.3/bin:/opt/cabal/1.22/bin:$PATH
+    - export PATH=~/.cabal/bin:$PATH
+    - cabal update
+
+script:
+    - cabal install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
             - alex-3.1.4
             - cabal-install-1.22
 
+cache:
+    directories:
+        - $HOME/.cabal
+
 before_install:
     - grep '\(MemTotal\|SwapTotal\)' /proc/meminfo
     - git show | head -1  # (for matching against commit hash given on the travis log web page)

--- a/README
+++ b/README
@@ -1,1 +1,4 @@
+[![Build Status](https://travis-ci.org/liqd/aula.svg?branch=master)](https://travis-ci.org/liqd/aula)
+
 status: just brainstorming
+


### PR DESCRIPTION
The build on [travis](https://travis-ci.org/liqd/aula) now tries to install aula. There is a build state indicator in the README file.

NOTE: Somehow the travis cache is not working as expected, but until the build does not reach critical timelimit or number of pushes/hour. We can live with it. (E.g. The resolution could be done via docker image, I've it done before)