### PR TITLE
Dockerize travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,13 @@
+sudo: required
+services:
+    - docker
 language: c
-
-sudo: false
-
-addons:
-    apt:
-        sources:
-            - hvr-ghc
-        packages:
-            - ghc-7.10.3
-            - happy-1.19.3
-            - alex-3.1.4
-            - cabal-install-1.22
 
 before_install:
     - grep '\(MemTotal\|SwapTotal\)' /proc/meminfo
     - git show | head -1  # (for matching against commit hash given on the travis log web page)
-    - export PATH=/opt/ghc/7.10.3/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.3/bin:/opt/cabal/1.22/bin:$PATH
-    - export PATH=~/.cabal/bin:$PATH
-    - cabal update
-    - cabal --version
+    - docker pull fisx/aula
+    - docker run --rm -it -v `pwd`:/root/aula/ fisx/aula /bin/sh -c "/root/aula/travis/docker-list-sandbox-packages.sh"
 
 script:
-    - cabal install --enable-tests --only-dependencies --reorder-goals
-    - cabal configure --enable-tests --disable-optimization
-    - cabal build
-    - cabal test --show-details=streaming
+    - docker run --rm -it -v `pwd`:/root/aula/ fisx/aula /bin/sh -c "/root/aula/travis/docker-build.sh"

--- a/travis/docker-build.sh
+++ b/travis/docker-build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Change to the source directory which is attacehed as docker volume
+cd /root/aula
+
+# Init cabal sandbox environment
+cabal update
+cabal sandbox init --sandbox=/liqd/thentos/.cabal-sandbox
+
+# Install from the current code
+cabal install --enable-tests --only-dependencies --reorder-goals
+cabal configure --enable-tests --disable-optimization
+cabal build
+
+# Test
+cabal test --show-details=never
+RESULT=`echo $?`
+cat dist/test/aula-*-tests.log
+
+exit $RESULT

--- a/travis/docker-list-sandbox-packages.sh
+++ b/travis/docker-list-sandbox-packages.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd /root/aula
+
+cabal sandbox init --sandbox=/liqd/thentos/.cabal-sandbox
+cabal exec -- ghc-pkg list


### PR DESCRIPTION
Steps what the travis build does at testing:

 * Pulls out the `fisx/aula` docker image, which has thentos and aula dependencies installed in a cabal sandbox `/liqd/thentos/.cabal-sandbox`. 
 * Show the versions of installed packages for debug purposes
 * Runs the normal cabal test suite that can be found in `travis/docker-build.sh` 