### PR TITLE
Extend the DB with users and current user

### DIFF
--- a/src/Api/Persistent.hs
+++ b/src/Api/Persistent.hs
@@ -9,12 +9,25 @@
 
 module Api.Persistent
     ( Persist
+    , AulaData
     , mkRunPersist
+    , getDb
+    , addDb
+    , modifyDb
     , getIdeas
     , addIdea
+    , getUsers
+    , addUser
+    , findUserByLogin
+    , loginUser
+    , dbIdeas
+    , dbUsers
+    , dbCurrentUser
     )
 where
 
+import Data.Foldable (find)
+import Data.String.Conversions
 import Control.Concurrent.STM
 import Control.Monad.Trans.Reader
 import Control.Lens
@@ -26,13 +39,15 @@ import Types
 
 data AulaData = AulaData
     { _dbIdeas :: [Idea]
+    , _dbUsers :: [User]
+    , _dbCurrentUser :: Maybe (AUID User)
     }
   deriving (Eq, Show, Read)
 
 makeLenses ''AulaData
 
 emptyAulaData :: AulaData
-emptyAulaData = AulaData []
+emptyAulaData = AulaData [] [] Nothing
 
 -- | FIXME: call this type 'Action'?  Or 'Aula'?  Or 'AulaAction'?  As of the time of writing this
 -- comment, it doesn't make sense to have separate abstractions for persistence layer (Transaction
@@ -46,8 +61,30 @@ mkRunPersist = do
     let run (Persist c) = c `runReaderT` tvar
     return $ Nat run
 
+getDb :: Lens' AulaData a -> Persist a
+getDb l = Persist . ReaderT $ fmap (view l) . atomically . readTVar
+
+modifyDb :: Lens' AulaData a -> (a -> a) -> Persist ()
+modifyDb l f = Persist . ReaderT $ \state -> atomically $ modifyTVar' state (l %~ f)
+
+addDb :: Lens' AulaData [a] -> a -> Persist ()
+addDb l a = modifyDb l (a:)
+
 getIdeas :: Persist [Idea]
-getIdeas = Persist . ReaderT $ fmap (view dbIdeas) . atomically . readTVar
+getIdeas = getDb dbIdeas
 
 addIdea :: Idea -> Persist ()
-addIdea idea = Persist . ReaderT $ \state -> atomically $ modifyTVar' state (dbIdeas %~ (idea:))
+addIdea = addDb dbIdeas
+
+getUsers :: Persist [User]
+getUsers = getDb dbUsers
+
+addUser :: User -> Persist ()
+addUser = addDb dbUsers
+
+findUserByLogin :: ST -> Persist (Maybe User)
+findUserByLogin login = find (\u -> u ^. userLogin == login) <$> getUsers
+
+-- | FIXME: anyone can login
+loginUser :: ST -> Persist ()
+loginUser login = modifyDb dbCurrentUser . const . fmap (view userId) =<< findUserByLogin login

--- a/src/Api/Persistent.hs
+++ b/src/Api/Persistent.hs
@@ -87,4 +87,4 @@ findUserByLogin login = find (\u -> u ^. userLogin == login) <$> getUsers
 
 -- | FIXME: anyone can login
 loginUser :: ST -> Persist ()
-loginUser login = modifyDb dbCurrentUser . const . fmap (view userId) =<< findUserByLogin login
+loginUser login = modifyDb dbCurrentUser . const . fmap (view _Id) =<< findUserByLogin login

--- a/src/Frontend/Html.hs
+++ b/src/Frontend/Html.hs
@@ -44,6 +44,12 @@ instance (ToMarkup body) => ToMarkup (Frame body) where
             link ! rel "stylesheet" ! href "/screen.css"
         body (headerMarkup >> toMarkup bdy >> footerMarkup)
 
+-- | Debugging page, uses the 'Show' instance of the underlying type.
+newtype PageShow a = PageShow { _unPageShow :: a }
+
+instance Show a => ToMarkup (PageShow a) where
+    toMarkup = pre . code . toMarkup . show . _unPageShow
+
 newtype CommentVotesWidget = VotesWidget (Set CommentVote)
 
 instance ToMarkup CommentVotesWidget where

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -10,7 +10,7 @@
 module Types
 where
 
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses, Lens')
 import Control.Monad
 import Data.Binary
 import Data.Char
@@ -301,3 +301,33 @@ makeLenses ''SchoolClass
 makeLenses ''Topic
 makeLenses ''UpDown
 makeLenses ''User
+
+userId              :: Lens' User (AUID User)
+userId              = userMeta . metaId
+userCreatedBy       :: Lens' User (AUID User)
+userCreatedBy       = userMeta . metaCreatedBy
+userCreatedByLogin  :: Lens' User ST
+userCreatedByLogin  = userMeta . metaCreatedByLogin
+userCreatedByAvatar :: Lens' User URL
+userCreatedByAvatar = userMeta . metaCreatedByAvatar
+userCreatedAt       :: Lens' User Timestamp
+userCreatedAt       = userMeta . metaCreatedAt
+userChangedBy       :: Lens' User (AUID User)
+userChangedBy       = userMeta . metaChangedBy
+userChangedAt       :: Lens' User Timestamp
+userChangedAt       = userMeta . metaChangedAt
+
+ideaId              :: Lens' Idea (AUID Idea)
+ideaId              = ideaMeta . metaId
+ideaCreatedBy       :: Lens' Idea (AUID User)
+ideaCreatedBy       = ideaMeta . metaCreatedBy
+ideaCreatedByLogin  :: Lens' Idea ST
+ideaCreatedByLogin  = ideaMeta . metaCreatedByLogin
+ideaCreatedByAvatar :: Lens' Idea URL
+ideaCreatedByAvatar = ideaMeta . metaCreatedByAvatar
+ideaCreatedAt       :: Lens' Idea Timestamp
+ideaCreatedAt       = ideaMeta . metaCreatedAt
+ideaChangedBy       :: Lens' Idea (AUID User)
+ideaChangedBy       = ideaMeta . metaChangedBy
+ideaChangedAt       :: Lens' Idea Timestamp
+ideaChangedAt       = ideaMeta . metaChangedAt

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -302,32 +302,28 @@ makeLenses ''Topic
 makeLenses ''UpDown
 makeLenses ''User
 
-userId              :: Lens' User (AUID User)
-userId              = userMeta . metaId
-userCreatedBy       :: Lens' User (AUID User)
-userCreatedBy       = userMeta . metaCreatedBy
-userCreatedByLogin  :: Lens' User ST
-userCreatedByLogin  = userMeta . metaCreatedByLogin
-userCreatedByAvatar :: Lens' User URL
-userCreatedByAvatar = userMeta . metaCreatedByAvatar
-userCreatedAt       :: Lens' User Timestamp
-userCreatedAt       = userMeta . metaCreatedAt
-userChangedBy       :: Lens' User (AUID User)
-userChangedBy       = userMeta . metaChangedBy
-userChangedAt       :: Lens' User Timestamp
-userChangedAt       = userMeta . metaChangedAt
+class HasMetaInfo a where
+    metaInfo        :: Lens' a (MetaInfo a)
+    _Id             :: Lens' a (AUID a)
+    _Id             = metaInfo . metaId
+    createdBy       :: Lens' a (AUID User)
+    createdBy       = metaInfo . metaCreatedBy
+    createdByLogin  :: Lens' a ST
+    createdByLogin  = metaInfo . metaCreatedByLogin
+    createdByAvatar :: Lens' a URL
+    createdByAvatar = metaInfo . metaCreatedByAvatar
+    createdAt       :: Lens' a Timestamp
+    createdAt       = metaInfo . metaCreatedAt
+    changedBy       :: Lens' a (AUID User)
+    changedBy       = metaInfo . metaChangedBy
+    changedAt       :: Lens' a Timestamp
+    changedAt       = metaInfo . metaChangedAt
 
-ideaId              :: Lens' Idea (AUID Idea)
-ideaId              = ideaMeta . metaId
-ideaCreatedBy       :: Lens' Idea (AUID User)
-ideaCreatedBy       = ideaMeta . metaCreatedBy
-ideaCreatedByLogin  :: Lens' Idea ST
-ideaCreatedByLogin  = ideaMeta . metaCreatedByLogin
-ideaCreatedByAvatar :: Lens' Idea URL
-ideaCreatedByAvatar = ideaMeta . metaCreatedByAvatar
-ideaCreatedAt       :: Lens' Idea Timestamp
-ideaCreatedAt       = ideaMeta . metaCreatedAt
-ideaChangedBy       :: Lens' Idea (AUID User)
-ideaChangedBy       = ideaMeta . metaChangedBy
-ideaChangedAt       :: Lens' Idea Timestamp
-ideaChangedAt       = ideaMeta . metaChangedAt
+instance HasMetaInfo CommentVote where metaInfo = commentVoteMeta
+instance HasMetaInfo Delegation where metaInfo = delegationMeta
+instance HasMetaInfo Feasible where metaInfo = feasibleMeta
+instance HasMetaInfo Idea where metaInfo = ideaMeta
+instance HasMetaInfo IdeaLike where metaInfo = likeMeta
+instance HasMetaInfo IdeaVote where metaInfo = ideaVoteMeta
+instance HasMetaInfo Topic where metaInfo = topicMeta
+instance HasMetaInfo User where metaInfo = userMeta


### PR DESCRIPTION
Additions to Api.Persistent:

* getDb
* addDb
* modifyDb
* getUsers
* addUser
* findUserByLogin
* loginUser
* dbUsers
* dbCurrentUser

New endpoints in Frontend:

* GET users/create_random
* GET users
* GET login/:login

Frontend.Html:

* Add PageShow which enables to write dev pages using the underlying Show instance.

Types:

* Add lenses for direct access to the meta data of users and ideas.