### PR TITLE
Use sensei to drive exec/RenderHtml.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,18 @@ FULL_SOURCES=-isrc -itests -i$(THENTOS_ROOT_PATH)/thentos-core/src/ -i$(THENTOS_
 
 .phony:
 
+%.unregister:
+	-cabal exec -- ghc-pkg unregister $*
+
+unregister-full:
+	make thentos-adhocracy.unregister thentos-tests.unregister thentos-core.unregister aula.unregister
+
 # only aware of aula sources
-sensei: .phony
+sensei: .phony aula.unregister
 	cabal exec -- sensei -isrc -itests tests/Spec.hs $(SENSEI_ARGS)
 
 # aware of aula and thentos sources
-sensei-full: .phony
+sensei-full: .phony unregister-full
 	cabal exec -- sensei $(FULL_SOURCES) -optP-DDEVELOPMENT ./tests/Spec.hs $(SENSEI_ARGS)
 
 seito: .phony
@@ -20,7 +26,7 @@ aula-server: .phony
 click-dummies-recreate: .phony
 	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/RenderHtml.hs
 
-click-dummies-refresh: .phony
+click-dummies-refresh: .phony aula.unregister
 	cabal exec -- sensei $(FULL_SOURCES) ./exec/RenderHtml.hs
 
 test-repl:

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,13 @@ seito: .phony
 	sleep 0.2 && seito
 
 aula-server: .phony
-	cabal exec -- ghci $(FULL_SOURCES) ./exec/Aula.hs
-
-aula-server-run: .phony
-	cabal run -- aula-server
+	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/Aula.hs
 
 click-dummies-recreate: .phony
-	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/RenderHtml.hs --recreate
+	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/RenderHtml.hs
 
 click-dummies-refresh: .phony
-	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/RenderHtml.hs --refresh
+	cabal exec -- sensei $(FULL_SOURCES) ./exec/RenderHtml.hs
 
 test-repl:
 	cabal exec -- ghci $(FULL_SOURCES)

--- a/README.md
+++ b/README.md
@@ -64,22 +64,35 @@ to some of the runCabal invocations.
 
 ## HTML hacking
 
-To watch some generated test content (mostly for work on HTML / css):
+To create arbitrary (randomized) test content and browse it (mostly
+for work on HTML / css):
 
 ```shell
 cabal sandbox init
 cabal install
-cabal run -- aula-server
+make click-dummies-recreate
+make aula-server
 ```
 
-To re-generate the HTML:
+To refresh the HTML from the same content (same texts and everything):
 
 ```shell
-cabal run -- aula-html-dummies --refresh
+make click-dummies-refresh
 ```
 
-To generate new haskell data values (implies re-generation of HTML):
+The html pages are created in `/tmp/aula-samples/`, and can be browsed
+under `http://localhost:8080/samples/`.  You can either edit the html
+pages directly, or the source code in this repo under
+`src/Frontend/Page/*.hs`.  If you edit `src/...`, `/tmp/aula-samples/`
+will be overwritten.  If you want to keep changes you did to the
+generated html code, you can initialize a local git repo (`cd
+/tmp/aula-samples && git init`) and commit your changes before editing
+the haskell sources.  If you do so, you can use `git diff` to make
+sure that the haskell code does what you expected.
 
-```shell
-cabal run -- aula-html-dummies --recreate
-```
+Both `aula-server` and `click-dummies-refresh` go into a loop, so you
+need to terminals.  If you have two displays, you can move your
+browser and the terminal with the refresh loop to one, and your source
+code editor to the other.  The source code will auto-refresh on the
+former and you will never have to focus there, no matter whether you
+work on the haskell sources or on the html.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To create arbitrary (randomized) test content and browse it (mostly
 for work on HTML / css):
 
 ```shell
+export AULA_SAMPLES=/tmp/aula-samples/
 cabal sandbox init
 cabal install
 make click-dummies-recreate

--- a/aula.cabal
+++ b/aula.cabal
@@ -109,13 +109,14 @@ executable aula-html-dummies
       base >=4.8 && <4.9
     , aula
 
+    , extra
+    , hspec
     , binary
     , bytestring
     , cassava
     , containers
     , cookie
     , directory
-    , fsnotify
     , lens
     , lucid
     , mtl

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -128,17 +128,13 @@ recreateSamples = do
     writeSample :: (Int, (TypeRep, String)) -> IO ()
     writeSample (ix, (typRep, valueRepShow)) = do
         let fn :: FilePath
-            fn = showNum ix <> "_" <> showPageName typRep
+            fn = showNum ix <> "_" <> (tr <$> show typRep)
 
-            showNum :: Int -> String
             showNum i | i < 999 = reverse . take 3 . reverse $ "000" <> show ix
                       | otherwise = assert False $ error "recreateSamples: impossible."
 
-            showPageName :: (Show a) => a -> String
-            showPageName = map f . show
-              where
-                f ' ' = '_'
-                f c = c
+            tr ' ' = '_'
+            tr  c  =  c
 
         writeFile (fn <.> "hs")              valueRepShow
         writeFile (fn <.> "hs" <.> "html") $ "<pre>" <> valueRepShow <> "</pre>"

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -181,6 +181,10 @@ dynamicRender s = case catMaybes $ pages g of
                         `catch` (\(SomeException _) -> return Nothing)
 
     f :: forall a. (Read a, ToHtml a) => Proxy a -> ST -> ST
-    f Proxy s'' = v `seq` (cs . renderText . toHtml . Frame frameUserHack $ v)
+    f Proxy s'' = v `seq` (cs . renderText . pf $ v)
       where
-        v = read (cs s'') :: a
+        v :: a
+        v = read s''
+
+        pf :: a -> Html ()
+        pf = pageFrame' [meta_ [httpEquiv_ "refresh", content_ "1"]] . toHtml

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -1,131 +1,142 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
 {-# OPTIONS_GHC -Werror -Wall #-}
 
 
-module Main (main) where
+module Main (main, spec) where
 
-import Control.Concurrent (threadDelay)
 import Control.Exception (assert, catch, SomeException(SomeException))
-import Control.Lens ((^.))
-import Control.Monad (forM_, unless, when, void, forever)
+import Control.Monad (forM_, unless, when, void)
 import Data.Maybe (catMaybes)
 import Data.String.Conversions
 import Data.Typeable (Typeable, Proxy(Proxy), TypeRep, typeOf)
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import Lucid
 import System.Directory
-import System.Environment
+import System.Directory.Extra
 import System.Exit
 import System.FilePath
-import System.FSNotify
 import System.IO hiding (utf8)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Process
+import Test.Hspec
 import Test.QuickCheck
 import Text.Show.Pretty (ppShow)
 
 import qualified Data.Text.IO as ST
 
 import Arbitrary ()
-import Config
 import Frontend.Page
 
 
-samplePages :: IO [(TypeRep, String)]
-samplePages = sequence
-    [ f <$> (generate arbitrary :: IO PageRoomsOverview)
-    , f <$> (generate arbitrary :: IO PageIdeasOverview)
-    , f <$> (generate arbitrary :: IO PageIdeasInDiscussion)
-    , f <$> (generate arbitrary :: IO PageTopicOverviewRefinementPhase)
-    , f <$> (generate arbitrary :: IO PageTopicOverviewJuryPhase)
-    , f <$> (generate arbitrary :: IO PageTopicOverviewVotingPhase)
-    , f <$> (generate arbitrary :: IO PageTopicOverviewResultPhase)
-    , f <$> (generate arbitrary :: IO PageTopicOverviewDelegations)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailNewIdeas)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailRefinementPhase)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailJuryPhase)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailVotingPhase)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailMoveIdeaToTopic)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailFeasibleNotFeasible)
-    , f <$> (generate arbitrary :: IO PageIdeaDetailWinner)
-    , f <$> (generate arbitrary :: IO PageCreateIdea)
-    , f <$> (generate arbitrary :: IO PageEditIdea)
-    , f <$> (generate arbitrary :: IO PageUserProfileCreateIdeas)
-    , f <$> (generate arbitrary :: IO PageUserProfileDelegatedVotes)
-    , f <$> (generate arbitrary :: IO PageUserSettings)
-    , f <$> (generate arbitrary :: IO PageCreateTopic)
-    , f <$> (generate arbitrary :: IO PageCreateTopicAddIdeas)
-    , f <$> (generate arbitrary :: IO PageAdminSettingsDurationsAndQuorum)
-    , f <$> (generate arbitrary :: IO PageAdminSettingsGroupsAndPermissions)
-    , f <$> (generate arbitrary :: IO PageAdminSettingsUserCreateAndImport)
-    , f <$> (generate arbitrary :: IO PageAdminSettingsEventsProtocol)
-    , f <$> (generate arbitrary :: IO PageDelegateVote)
-    , f <$> (generate arbitrary :: IO PageDelegationNetwork)
-    , f <$> (generate arbitrary :: IO PageStaticImprint)
-    , f <$> (generate arbitrary :: IO PageStaticTermsOfUse)
-    , f <$> (generate arbitrary :: IO PageHomeWithLoginPrompt)
+-- | config section: add new page types here.
+pages :: forall b.
+    (forall a. (Typeable a, Arbitrary a, Show a, Read a, ToHtml a) => Proxy a -> b)
+    -> [b]
+pages f =
+    [ f (Proxy :: Proxy PageRoomsOverview)
+    , f (Proxy :: Proxy PageIdeasOverview)
+    , f (Proxy :: Proxy PageIdeasInDiscussion)
+    , f (Proxy :: Proxy PageTopicOverviewRefinementPhase)
+    , f (Proxy :: Proxy PageTopicOverviewJuryPhase)
+    , f (Proxy :: Proxy PageTopicOverviewVotingPhase)
+    , f (Proxy :: Proxy PageTopicOverviewResultPhase)
+    , f (Proxy :: Proxy PageTopicOverviewDelegations)
+    , f (Proxy :: Proxy PageIdeaDetailNewIdeas)
+    , f (Proxy :: Proxy PageIdeaDetailRefinementPhase)
+    , f (Proxy :: Proxy PageIdeaDetailJuryPhase)
+    , f (Proxy :: Proxy PageIdeaDetailVotingPhase)
+    , f (Proxy :: Proxy PageIdeaDetailMoveIdeaToTopic)
+    , f (Proxy :: Proxy PageIdeaDetailFeasibleNotFeasible)
+    , f (Proxy :: Proxy PageIdeaDetailWinner)
+    , f (Proxy :: Proxy PageCreateIdea)
+    , f (Proxy :: Proxy PageEditIdea)
+    , f (Proxy :: Proxy PageUserProfileCreateIdeas)
+    , f (Proxy :: Proxy PageUserProfileDelegatedVotes)
+    , f (Proxy :: Proxy PageUserSettings)
+    , f (Proxy :: Proxy PageCreateTopic)
+    , f (Proxy :: Proxy PageCreateTopicAddIdeas)
+    , f (Proxy :: Proxy PageAdminSettingsDurationsAndQuorum)
+    , f (Proxy :: Proxy PageAdminSettingsGroupsAndPermissions)
+    , f (Proxy :: Proxy PageAdminSettingsUserCreateAndImport)
+    , f (Proxy :: Proxy PageAdminSettingsEventsProtocol)
+    , f (Proxy :: Proxy PageDelegateVote)
+    , f (Proxy :: Proxy PageDelegationNetwork)
+    , f (Proxy :: Proxy PageStaticImprint)
+    , f (Proxy :: Proxy PageStaticTermsOfUse)
+    , f (Proxy :: Proxy PageHomeWithLoginPrompt)
     ]
+
+
+-- | main: recreate and refresh data once and terminate.  (for refresh loop, use hspec/sensei.)
+--
+-- FIXME: check out blaze-from-html package (lucid doesn't seem to have that yet).
+-- FIXME: write documentation
+main :: IO ()
+main = run $ recreateSamples >> refreshSamples
+
+
+-- | hspec test case: for the sensei loop
+spec :: Spec
+spec = describe "refresh html samples" . it "works" . run $ refreshSamples
+
+
+-- | set locale, target directory.  create target directory if missing.
+run :: IO () -> IO ()
+run action = do
+    setLocaleEncoding utf8
+    createDirectoryIfMissing True targetPath
+    withCurrentDirectory targetPath action
+
+
+-- | target path is rather rigit, if you ever change this, make sure it is kept in sync with the
+-- `static/samples` symlink.
+targetPath :: FilePath
+targetPath = "/tmp/aula-samples"
+
+
+-- | generate new arbitrary instances; return their 'show' and 'typeOf'.
+samplePages :: IO [(TypeRep, String)]
+samplePages = sequence $ pages g
   where
+    g :: forall a. (Typeable a, Arbitrary a, Show a, Read a, ToHtml a)
+        => Proxy a -> IO (TypeRep, String)
+    g Proxy = f <$> (generate arbitrary :: IO a)
+
     f :: (Typeable a, Show a, ToHtml a) => a -> (TypeRep, String)
     f x = (typeOf x, terminatingShow x)
 
     terminatingShow :: (Show a) => a -> String
     terminatingShow x = if length s < n then s else error e
       where
-        n = 1000000
+        n = 10*1000*1000
+        n' = 1000
         s = take n $ ppShow x
-        e = "terminatingShow: " <> s
-
-
--- | ...
---
--- FIXME: check out blaze-from-html package (lucid doesn't seem to have that yet).
--- FIXME: document
-main :: IO ()
-main = do
-    setLocaleEncoding utf8
-    setCurrentDirectoryToAulaRoot
-    args <- getArgs
-    progName <- getProgName
-    case args of
-        ["--recreate"] -> recreateSamples
-        ["--refresh"]  -> refreshSamples
-        ["--watch"]    -> refreshSamples >> void watchRefresh
-        _ -> error $ "usage: " <> progName <> " [--recreate|--refresh|--watch]"
-
-
-withSamplesDirectoryCurrent :: IO () -> IO ()
-withSamplesDirectoryCurrent action = do
-    let path = Config.config ^. Config.htmlStatic </> "samples"
-    createDirectoryIfMissing True path
-    oldPath <- getCurrentDirectory
-    setCurrentDirectory path
-    action
-    setCurrentDirectory oldPath
+        e = "terminatingShow: " <> take n' s
 
 
 -- | Remove existing samples and generate new ones.
 recreateSamples :: IO ()
 recreateSamples = do
     putStrLn "recreate..."
-    withSamplesDirectoryCurrent $ do
-        _ <- system "rm -f *.hs *.html"
-        samplePages >>= mapM_ writeSample . zip [1..]
+    _ <- system "rm -f *.hs *.html"
+    samplePages >>= mapM_ writeSample . zip [1..]
     putStrLn "done."
-    refreshSamples
   where
     writeSample :: (Int, (TypeRep, String)) -> IO ()
     writeSample (ix, (typRep, valueRepShow)) = do
         let fn :: FilePath
-            fn | ix < 100 = (reverse . take 3 . reverse $ "000" <> show ix <> "_")
-                         <> show' typRep
-               | otherwise = assert False $ error "recreateSamples: impossible."
+            fn = showNum ix <> "_" <> showPageName typRep
 
-            show' :: (Show a) => a -> String
-            show' = map f . show
+            showNum :: Int -> String
+            showNum i | i < 999 = reverse . take 3 . reverse $ "000" <> show ix
+                      | otherwise = assert False $ error "recreateSamples: impossible."
+
+            showPageName :: (Show a) => a -> String
+            showPageName = map f . show
               where
                 f ' ' = '_'
                 f c = c
@@ -136,8 +147,10 @@ recreateSamples = do
 
 -- | Read existing samples and re-render the HTML.
 refreshSamples :: IO ()
-refreshSamples = withSamplesDirectoryCurrent $ do
+refreshSamples = do
     putStrLn "refresh..."
+
+    -- check if tidy is available.  warns if not, but it'll still work!
     withTidy :: Bool <- (== ExitSuccess) <$> system "which tidy >/dev/null"
     unless withTidy $ do
         hPutStrLn stderr "WARNING: tidy not in path.  will not generate pretty-printed pages."
@@ -156,54 +169,12 @@ refreshSamples = withSamplesDirectoryCurrent $ do
     putStrLn "done."
 
 
--- | run --refresh on changes in ./src.  (Ideally, this would use ghcid to keep the code in memory
--- and only reload the parts that have changed.  sensei does that.)
-watchRefresh :: IO StopListening
-watchRefresh = withManager $ \mgr -> do
-    let sleep = threadDelay 1000000
-        action = system "date; time cabal run -- aula-html-dummies --refresh"
-    _ <- watchTree mgr "src" (\_ -> True) (\_ -> action >> sleep)
-    forever sleep
-
-
 -- | Take a binary serialization and use current 'ToHtml' instances for
 dynamicRender :: ST -> ST
-dynamicRender s = case catMaybes
-            [ g (Proxy :: Proxy PageRoomsOverview)
-            , g (Proxy :: Proxy PageIdeasOverview)
-            , g (Proxy :: Proxy PageIdeasInDiscussion)
-            , g (Proxy :: Proxy PageTopicOverviewRefinementPhase)
-            , g (Proxy :: Proxy PageTopicOverviewJuryPhase)
-            , g (Proxy :: Proxy PageTopicOverviewVotingPhase)
-            , g (Proxy :: Proxy PageTopicOverviewResultPhase)
-            , g (Proxy :: Proxy PageTopicOverviewDelegations)
-            , g (Proxy :: Proxy PageIdeaDetailNewIdeas)
-            , g (Proxy :: Proxy PageIdeaDetailRefinementPhase)
-            , g (Proxy :: Proxy PageIdeaDetailJuryPhase)
-            , g (Proxy :: Proxy PageIdeaDetailVotingPhase)
-            , g (Proxy :: Proxy PageIdeaDetailMoveIdeaToTopic)
-            , g (Proxy :: Proxy PageIdeaDetailFeasibleNotFeasible)
-            , g (Proxy :: Proxy PageIdeaDetailWinner)
-            , g (Proxy :: Proxy PageCreateIdea)
-            , g (Proxy :: Proxy PageEditIdea)
-            , g (Proxy :: Proxy PageUserProfileCreateIdeas)
-            , g (Proxy :: Proxy PageUserProfileDelegatedVotes)
-            , g (Proxy :: Proxy PageUserSettings)
-            , g (Proxy :: Proxy PageCreateTopic)
-            , g (Proxy :: Proxy PageCreateTopicAddIdeas)
-            , g (Proxy :: Proxy PageAdminSettingsDurationsAndQuorum)
-            , g (Proxy :: Proxy PageAdminSettingsGroupsAndPermissions)
-            , g (Proxy :: Proxy PageAdminSettingsUserCreateAndImport)
-            , g (Proxy :: Proxy PageAdminSettingsEventsProtocol)
-            , g (Proxy :: Proxy PageDelegateVote)
-            , g (Proxy :: Proxy PageDelegationNetwork)
-            , g (Proxy :: Proxy PageStaticImprint)
-            , g (Proxy :: Proxy PageStaticTermsOfUse)
-            , g (Proxy :: Proxy PageHomeWithLoginPrompt)
-            ] of
+dynamicRender s = case catMaybes $ pages g of
     (v:_) -> v
-    [] -> error $ "dynamicRender: problem parsing the following type." <>
-                  "  run with --recreate?\n\n" <> cs s <> "\n\n"
+    [] -> error $ "dynamicRender: problem parsing the type of the following value." <>
+                  "  recreate samples?\n\n" <> cs s <> "\n\n"
   where
     g :: forall a. (Read a, ToHtml a) => Proxy a -> Maybe ST
     g proxy = unsafePerformIO $ (case f proxy s of !s' -> return $ Just s')

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -27,6 +27,7 @@ import Text.Show.Pretty (ppShow)
 import qualified Data.Text.IO as ST
 
 import Arbitrary ()
+import Config (getSamplesPath)
 import Frontend.Page
 import Types (readWith, User)
 
@@ -87,14 +88,9 @@ spec = describe "refresh html samples" . it "works" . run $ refreshSamples
 run :: IO () -> IO ()
 run action = do
     setLocaleEncoding utf8
-    createDirectoryIfMissing True targetPath
-    withCurrentDirectory targetPath action
-
-
--- | target path is rather rigit, if you ever change this, make sure it is kept in sync with the
--- `static/samples` symlink.
-targetPath :: FilePath
-targetPath = "/tmp/aula-samples"
+    samplesPath <- getSamplesPath
+    createDirectoryIfMissing True samplesPath
+    withCurrentDirectory samplesPath action
 
 
 -- | generate new arbitrary instances; return their 'show' and 'typeOf'.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,6 +5,8 @@ module Config
 where
 
 import Control.Lens
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
 import System.Directory
 import System.Environment
 
@@ -29,3 +31,10 @@ config = Config
 setCurrentDirectoryToAulaRoot :: IO ()
 setCurrentDirectoryToAulaRoot = do
     getEnvironment >>= maybe (pure ()) setCurrentDirectory . lookup "AULA_ROOT_PATH"
+
+
+getSamplesPath :: IO FilePath
+getSamplesPath = fromMaybe (error msg) . lookup var <$> getEnvironment
+  where
+    var = "AULA_SAMPLES"
+    msg = "please set $" <> var <> " to a path (will be created if n/a)"

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -71,11 +71,14 @@ type FrontendH =
 
 type Aula =
        FrontendH
-  :<|> Raw
+  :<|> "samples" :> Raw
+  :<|> Raw  -- FIXME: change this to @"static" :> Raw@
+            -- (@Raw@ on the empty path may accidentally process other end-points)
 
 aula :: (Action :~> ExceptT ServantErr IO) -> Server Aula
 aula (Nat runAction) =
        enter runActionForceLogin frontendH
+  :<|> (\req cont -> getSamplesPath >>= \path -> serveDirectory path req cont)
   :<|> serveDirectory (Config.config ^. htmlStatic)
   where
     -- FIXME: Login shouldn't happen here

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -108,10 +108,14 @@ publicPageFrame bdy = do
         publicHeaderMarkup >> bdy >> footerMarkup
 
 pageFrame :: (Monad m) => User -> HtmlT m a -> HtmlT m ()
-pageFrame usr bdy = do
+pageFrame usr = pageFrame' [] usr
+
+pageFrame' :: (Monad m) => [HtmlT m a] -> User -> HtmlT m a -> HtmlT m ()
+pageFrame' extraHeaders usr bdy = do
     head_ $ do
         title_ "AuLA"
         link_ [rel_ "stylesheet", href_ "/screen.css"]
+        sequence_ extraHeaders
     body_ $ do
         headerMarkup usr >> bdy >> footerMarkup
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -17,6 +17,7 @@ import Control.Lens (makeLenses, Lens')
 import Control.Monad
 import Data.Binary
 import Data.Char
+import Data.Proxy (Proxy(Proxy))
 import Data.Set (Set)
 import Data.String.Conversions
 import Data.Time
@@ -37,6 +38,10 @@ nil = mempty
 
 isNil :: (Monoid a, Eq a) => a -> Bool
 isNil = (== nil)
+
+readWith :: Read a => Proxy a -> String -> a
+readWith Proxy = read
+
 
 ----------------------------------------------------------------------
 -- prototypes for types

--- a/static/samples
+++ b/static/samples
@@ -1,0 +1,1 @@
+/tmp/aula-samples/

--- a/static/samples
+++ b/static/samples
@@ -1,1 +1,0 @@
-/tmp/aula-samples/

--- a/tests/FrontendSpec.hs
+++ b/tests/FrontendSpec.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -Werror -Wall #-}
+
+module FrontendSpec
+where
+
+import Test.Hspec
+import Frontend ()
+
+spec :: Spec
+spec = return ()


### PR DESCRIPTION
I just checked: on my laptop, I can set up sensei to watch the repo and on changes in src/Frontend/Page/*.hs, refresh of all html will take <3s.

The only problem is that sensei can't un-watch files.  See https://github.com/hspec/sensei/pull/28 for a discussion what needs to be done there.