### PR TITLE
Login Page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ seito: .phony
 aula-server: .phony
 	cabal exec -- ghci $(FULL_SOURCES) ./exec/Aula.hs
 
+aula-server-run: .phony
+	cabal run -- aula-server
+
 click-dummies-recreate: .phony
 	cabal exec -- runhaskell $(FULL_SOURCES) ./exec/RenderHtml.hs --recreate
 

--- a/aula.cabal
+++ b/aula.cabal
@@ -24,6 +24,8 @@ library
     , Frontend.Html
     , Frontend.Page.CreateIdea
     , Frontend.Topics
+    , Frontend.Page.HomePageWithLoginPrompt
+    , Frontend.Pages
     , Persistent
     , Transaction
     , Types

--- a/aula.cabal
+++ b/aula.cabal
@@ -23,8 +23,8 @@ library
     , Frontend.Core
     , Frontend.Html
     , Frontend.Page.CreateIdea
-    , Frontend.Topics
     , Frontend.Page.HomePageWithLoginPrompt
+    , Frontend.Page.Topics
     , Frontend.Pages
     , Persistent
     , Transaction

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -33,7 +33,7 @@ import Arbitrary ()
 import Config
 import Frontend.Core
 import Frontend.Html
-import Frontend.Page.CreateIdea
+import Frontend.Pages
 import Frontend.Topics
 
 

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -31,10 +31,7 @@ import qualified Data.Text.IO as ST
 
 import Arbitrary ()
 import Config
-import Frontend.Core
-import Frontend.Html
 import Frontend.Pages
-import Frontend.Topics
 
 
 samplePages :: IO [(TypeRep, String)]

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -19,9 +19,6 @@ import Test.QuickCheck (Arbitrary(..), Gen, elements, oneof, scale)
 import Test.QuickCheck.Instances ()
 
 import Types
-import Frontend.Html
-import Frontend.Page.CreateIdea
-import Frontend.Topics
 import Frontend.Pages
 
 

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -22,6 +22,7 @@ import Types
 import Frontend.Html
 import Frontend.Page.CreateIdea
 import Frontend.Topics
+import Frontend.Pages
 
 
 ----------------------------------------------------------------------

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -28,7 +28,7 @@ import Frontend.Html
 import Frontend.Topics hiding (pageTopicOverview)
 import Types
 
-import qualified Frontend.Page.CreateIdea as Page
+import qualified Frontend.Pages as Pages
 
 runFrontend :: IO ()
 runFrontend = runSettings settings . aulaTweaks $ serve (Proxy :: Proxy FrontendH) frontendH
@@ -43,12 +43,12 @@ type CreateRandom a = "create_random" :> GetH (Frame (ST `Beside` PageShow a))
 
 type FrontendH =
        GetH (Frame ST)
+  :<|> "login" :> FormH HTML (Html ()) ST
   :<|> "ideas" :> CreateRandom Idea
   :<|> "ideas" :> GetH (Frame PageIdeasOverview)
   :<|> "ideas" :> "create" :> FormH HTML (Html ()) ST
   :<|> "users" :> CreateRandom User
   :<|> "users" :> GetH (Frame (PageShow [User]))
-  :<|> "login" :> Capture "login" ST :> GetH (Frame ST)
   :<|> "topics" :> CreateRandom Topic
   :<|> "topics" :> GetH (Frame (PageShow [Topic]))
   :<|> "topics" :> Capture "topic" (AUID Topic) :> GetH (Frame PageTopicOverview)
@@ -60,12 +60,12 @@ render m = liftIO . runPersist $ Frame <$> m
 frontendH :: Server FrontendH
 frontendH =
        return (Frame "yihaah!")
+  :<|> Pages.login
   :<|> createRandom "idea" dbIdeaMap
   :<|> render (PageIdeasOverview <$> getIdeas)
-  :<|> Page.createIdea
+  :<|> Pages.createIdea
   :<|> createRandom "user" dbUserMap
   :<|> render (PageShow <$> getUsers)
-  :<|> (\login -> liftIO . runPersist $ Frame ("You are now logged in as " <> login) <$ loginUser login)
   :<|> createRandom "topic" dbTopicMap
   :<|> render (PageShow <$> getTopics)
   :<|> pageTopicOverview

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -23,12 +23,8 @@ import Persistent
 import Arbitrary ()
 import Config
 import CreateRandom
-import Frontend.Core
-import Frontend.Html
-import Frontend.Topics hiding (pageTopicOverview)
+import Frontend.Pages as Pages
 import Types
-
-import qualified Frontend.Pages as Pages
 
 runFrontend :: IO ()
 runFrontend = runSettings settings . aulaTweaks $ serve (Proxy :: Proxy FrontendH) frontendH
@@ -68,20 +64,5 @@ frontendH =
   :<|> render (PageShow <$> getUsers)
   :<|> createRandom "topic" dbTopicMap
   :<|> render (PageShow <$> getTopics)
-  :<|> pageTopicOverview
+  :<|> Pages.pageTopicOverview
   :<|> serveDirectory (Config.config ^. htmlStatic)
-
-pageTopicOverview :: MonadIO m => AUID Topic -> m (Frame PageTopicOverview)
-pageTopicOverview topicId = liftIO . runPersist $ do
-    -- FIXME 404
-    Just topic <- findTopic topicId
-    ideas      <- findIdeasByTopic topic
-    pure . Frame $ case topic ^. topicPhase of
-        PhaseRefinement -> PageTopicOverviewRefinementPhase' $ PageTopicOverviewRefinementPhase topic ideas
-        PhaseJury       -> PageTopicOverviewJuryPhase'       $ PageTopicOverviewJuryPhase       topic ideas
-        PhaseVoting     -> PageTopicOverviewVotingPhase'     $ PageTopicOverviewVotingPhase     topic ideas
-        PhaseResult     -> PageTopicOverviewResultPhase'     $ PageTopicOverviewResultPhase     topic ideas
-        -- FIXME: how do we display a topic in the finished phase?
-        -- Is this the same the result phase?
-        -- Maybe some buttons to hide?
-        PhaseFinished   -> PageTopicOverviewResultPhase'     $ PageTopicOverviewResultPhase     topic ideas

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -80,6 +80,14 @@ instance (ToHtml body) => ToHtml (Frame body) where
     toHtmlRaw          = toHtml
     toHtml (Frame bdy) = pageFrame (toHtml bdy)
 
+publicPageFrame :: (Monad m) => HtmlT m a -> HtmlT m ()
+publicPageFrame bdy = do
+    head_ $ do
+        title_ "AuLA"
+        link_ [rel_ "stylesheet", href_ "/screen.css"]
+    body_ $ do
+        publicHeaderMarkup >> bdy >> footerMarkup
+
 pageFrame :: (Monad m) => HtmlT m a -> HtmlT m ()
 pageFrame bdy = do
     head_ $ do
@@ -88,6 +96,12 @@ pageFrame bdy = do
     body_ $ do
         headerMarkup >> bdy >> footerMarkup
 
+publicHeaderMarkup :: (Monad m) => HtmlT m ()
+publicHeaderMarkup = div_ $ do
+    span_ "aula"
+    -- TODO: these should be links
+    span_ $ img_ [src_ "the_avatar"]
+    hr_ []
 
 headerMarkup :: (Monad m) => HtmlT m ()
 headerMarkup = div_ $ do

--- a/src/Frontend/Html.hs
+++ b/src/Frontend/Html.hs
@@ -272,18 +272,6 @@ instance ToHtml PageStaticTermsOfUse where
     toHtml p = semanticDiv p "PageStaticTermsOfUse"
 
 
--- | 16. Home page with login prompt
-data PageHomeWithLoginPrompt = PageHomeWithLoginPrompt
-  deriving (Eq, Show, Read)
-
-instance ToHtml PageHomeWithLoginPrompt where
-    toHtmlRaw = toHtml
-    toHtml p = semanticDiv p "PageHomeWithLoginPrompt"
-
-
-
-
-
 data PageIdea = PageIdea Idea
   deriving (Eq, Show, Read)
 

--- a/src/Frontend/Page/CreateIdea.hs
+++ b/src/Frontend/Page/CreateIdea.hs
@@ -18,6 +18,9 @@ import qualified Text.Digestive.Lucid.Html5 as DF
 data PageCreateIdea = PageCreateIdea
   deriving (Eq, Show, Read)
 
+instance Page PageCreateIdea where
+  isPrivatePage _ = True
+
 ----------------------------------------------------------------------
 -- templates
 
@@ -62,17 +65,8 @@ instance RedirectOf PageCreateIdea where
     redirectOf _ = "/ideas"
 
 createIdea :: Server (FormH HTML (Html ()) ST)
-createIdea = formRedirectH "/ideas/create" p1 p2 r
+createIdea = redirectFormHandler "/ideas/create" PageCreateIdea newIdea
   where
-    p1 :: DF.Form (Html ()) (ExceptT ServantErr IO) ProtoIdea
-    p1 = makeForm PageCreateIdea
-
-    p2 :: ProtoIdea -> ExceptT ServantErr IO ST
-    p2 idea = liftIO $ do
-        void . runPersist $ do
-            forceLogin 1 -- FIXME: Login hack
-            addIdea idea
-        return $ redirectOf PageCreateIdea
-
-    r :: View (Html ()) -> ST -> ExceptT ServantErr IO (Html ())
-    r v formAction = pure . pageFrame $ formPage v formAction PageCreateIdea
+    newIdea idea = liftIO $ runPersist $ do
+        forceLogin 1 -- FIXME: Login hack
+        addIdea idea

--- a/src/Frontend/Page/CreateIdea.hs
+++ b/src/Frontend/Page/CreateIdea.hs
@@ -45,23 +45,21 @@ instance FormPageView PageCreateIdea where
               , (CatEnvironment, "Umgebung")
               ]
 
-    formPage v formAction PageCreateIdea = do
-        div_ $ do
+    formPage v formAction p = do
+        semanticDiv p $ do
             h3_ "Create Idea"
             DF.form v formAction $ do
-                DF.inputText      "title" v
-                br_ []
-                DF.inputTextArea  Nothing Nothing "idea-text" v
-                br_ []
-                DF.inputSelect    "idea-category" v
-                br_ []
-                DF.inputSubmit "Add Idea"
+                DF.inputText     "title" v >> br_ []
+                DF.inputTextArea Nothing Nothing "idea-text" v >> br_ []
+                DF.inputSelect   "idea-category" v >> br_ []
+                DF.inputSubmit   "Add Idea"
 
-instance RedirectOf PageCreateIdea where
-    redirectOf _ = "/ideas"
 
 ----------------------------------------------------------------------
 -- handlers
+
+instance RedirectOf PageCreateIdea where
+    redirectOf _ = "/ideas"
 
 createIdea :: Server (FormH HTML (Html ()) ST)
 createIdea = formRedirectH "/ideas/create" p1 p2 r

--- a/src/Frontend/Page/HomePageWithLoginPrompt.hs
+++ b/src/Frontend/Page/HomePageWithLoginPrompt.hs
@@ -35,10 +35,12 @@ instance FormPageView PageHomeWithLoginPrompt where
 
     formPage v formAction p = do
         semanticDiv p $ do
-            DF.form v formAction $ do
+            div_ $ DF.form v formAction $ do
                 DF.inputText     "user" v >> br_ []
                 DF.inputPassword "pass" v >> br_ []
                 DF.inputSubmit   "Login"
+            div_ $ do
+                p_ $ "Solltest du dein Passwort nich mehr kennen, melde dich bitte bei den Admins euer Schule."
 
 ----------------------------------------------------------------------
 -- handlers
@@ -58,4 +60,4 @@ login = formRedirectH "/login" p1 p2 r
         return $ redirectOf PageHomeWithLoginPrompt
 
     r :: View (Html ()) -> ST -> ExceptT ServantErr IO (Html ())
-    r v formAction = pure . pageFrame $ formPage v formAction PageHomeWithLoginPrompt
+    r v formAction = pure . publicPageFrame $ formPage v formAction PageHomeWithLoginPrompt

--- a/src/Frontend/Page/HomePageWithLoginPrompt.hs
+++ b/src/Frontend/Page/HomePageWithLoginPrompt.hs
@@ -18,6 +18,8 @@ import qualified Text.Digestive.Lucid.Html5 as DF
 data PageHomeWithLoginPrompt = PageHomeWithLoginPrompt
   deriving (Eq, Show, Read)
 
+instance Page PageHomeWithLoginPrompt where
+  isPublicPage _ = True
 
 ----------------------------------------------------------------------
 -- templates
@@ -49,15 +51,6 @@ instance RedirectOf PageHomeWithLoginPrompt where
     redirectOf _ = "/ideas"
 
 login :: Server (FormH HTML (Html ()) ST)
-login = formRedirectH "/login" p1 p2 r
+login = redirectFormHandler "/login" PageHomeWithLoginPrompt makeUserLogin
   where
-    p1 :: DF.Form (Html ()) (ExceptT ServantErr IO) (ST, ST)
-    p1 = makeForm PageHomeWithLoginPrompt
-
-    p2 :: (ST, ST) -> ExceptT ServantErr IO ST
-    p2 (user, _pass) = liftIO $ do
-        runPersist $ loginUser user
-        return $ redirectOf PageHomeWithLoginPrompt
-
-    r :: View (Html ()) -> ST -> ExceptT ServantErr IO (Html ())
-    r v formAction = pure . publicPageFrame $ formPage v formAction PageHomeWithLoginPrompt
+    makeUserLogin (user, _pass) = liftIO . runPersist $ loginUser user

--- a/src/Frontend/Page/HomePageWithLoginPrompt.hs
+++ b/src/Frontend/Page/HomePageWithLoginPrompt.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Werror #-}
+
+module Frontend.Page.HomePageWithLoginPrompt
+where
+
+import Frontend.Prelude
+
+import qualified Text.Digestive.Form as DF
+import qualified Text.Digestive.Lucid.Html5 as DF
+
+----------------------------------------------------------------------
+-- page
+
+-- | 16. Home page with login prompt
+data PageHomeWithLoginPrompt = PageHomeWithLoginPrompt
+  deriving (Eq, Show, Read)
+
+
+----------------------------------------------------------------------
+-- templates
+
+instance ToHtml PageHomeWithLoginPrompt where
+    toHtmlRaw = toHtml
+    toHtml p = semanticDiv p "PageHomeWithLoginPrompt"
+
+instance FormPageView PageHomeWithLoginPrompt where
+    type FormPageResult PageHomeWithLoginPrompt = (ST, ST)
+
+    makeForm _ = do
+        (,) <$> ("user" .: DF.text Nothing)
+            <*> ("pass" .: DF.text Nothing)
+
+    formPage v formAction p = do
+        semanticDiv p $ do
+            DF.form v formAction $ do
+                DF.inputText     "user" v >> br_ []
+                DF.inputPassword "pass" v >> br_ []
+                DF.inputSubmit   "Login"
+
+----------------------------------------------------------------------
+-- handlers
+
+instance RedirectOf PageHomeWithLoginPrompt where
+    redirectOf _ = "/ideas"
+
+login :: Server (FormH HTML (Html ()) ST)
+login = formRedirectH "/login" p1 p2 r
+  where
+    p1 :: DF.Form (Html ()) (ExceptT ServantErr IO) (ST, ST)
+    p1 = makeForm PageHomeWithLoginPrompt
+
+    p2 :: (ST, ST) -> ExceptT ServantErr IO ST
+    p2 (user, _pass) = liftIO $ do
+        runPersist $ loginUser user
+        return $ redirectOf PageHomeWithLoginPrompt
+
+    r :: View (Html ()) -> ST -> ExceptT ServantErr IO (Html ())
+    r v formAction = pure . pageFrame $ formPage v formAction PageHomeWithLoginPrompt

--- a/src/Frontend/Pages.hs
+++ b/src/Frontend/Pages.hs
@@ -1,0 +1,6 @@
+module Frontend.Pages (module P)
+where
+
+import Frontend.Page.CreateIdea as P
+import Frontend.Page.HomePageWithLoginPrompt as P
+

--- a/src/Frontend/Pages.hs
+++ b/src/Frontend/Pages.hs
@@ -1,6 +1,10 @@
 module Frontend.Pages (module P)
 where
 
+import Frontend.Core as P
+import Frontend.Html as P
+
 import Frontend.Page.CreateIdea as P
 import Frontend.Page.HomePageWithLoginPrompt as P
+import Frontend.Page.Topics as P
 

--- a/tests/Frontend/HtmlSpec.hs
+++ b/tests/Frontend/HtmlSpec.hs
@@ -8,6 +8,7 @@ import Frontend.Core
 import Frontend.Html
 import Frontend.Page.CreateIdea
 import Frontend.Topics
+import Frontend.Pages
 
 import Control.Monad.Trans.Except
 import Data.Typeable (Typeable, typeOf)
@@ -59,6 +60,7 @@ spec = do
         ]
     context "PageFormView" $ mapM_ renderForm [
           F (arb :: Gen PageCreateIdea)
+        , F (arb :: Gen PageHomeWithLoginPrompt)
         ]
     where
         arb :: Arbitrary a => Gen a

--- a/tests/Frontend/HtmlSpec.hs
+++ b/tests/Frontend/HtmlSpec.hs
@@ -4,10 +4,6 @@
 module Frontend.HtmlSpec where
 
 import Arbitrary ()
-import Frontend.Core
-import Frontend.Html
-import Frontend.Page.CreateIdea
-import Frontend.Topics
 import Frontend.Pages
 
 import Control.Monad.Trans.Except

--- a/tests/Frontend/PageSpec.hs
+++ b/tests/Frontend/PageSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GADTs #-}
+
+{-# OPTIONS_GHC -Werror -Wall #-}
+
+module Frontend.PageSpec
+where
+
+import Arbitrary ()
+import Frontend.Pages
+
+
+import Data.Typeable (Typeable, typeOf)
+import Test.Hspec (Spec, describe, it, shouldNotBe)
+import Test.QuickCheck (Arbitrary(..), Gen, forAll, property)
+
+spec :: Spec
+spec = do
+    describe "Private and Public page should be inverse" $
+        mapM_ publicPagePrivatePageInverseProp [
+              P (arb :: Gen PageCreateIdea)
+            , P (arb :: Gen PageHomeWithLoginPrompt)
+            ]
+    where
+        arb :: Arbitrary a => Gen a
+        arb = arbitrary
+
+data PageGen where
+    P :: (Show p, Typeable p, Page p) => Gen p -> PageGen
+
+-- | Check if the public page and private page property are inverse.
+publicPagePrivatePageInverseProp :: PageGen -> Spec
+publicPagePrivatePageInverseProp (P g) =
+    it (show $ typeOf g) . property . forAll g $
+        \p -> isPublicPage p `shouldNotBe` isPrivatePage p


### PR DESCRIPTION
 * Different frame for the login page
 * Login handler which redirectes to ideas page after login (login always succeeds)
 * Rename `Frontend.Topic` to `Frontend.Page.Topics`
 * Create `Frontend.Pages` module
 * Add `make aula-server-run`
 * More compact form in `Frontend.Page.CreateIdea`
 * Add `Page` typeclass
 * Add `redirectFormHandler`