### PR TITLE
Add hlint to travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - git show | head -1  # (for matching against commit hash given on the travis log web page)
     - docker pull fisx/aula
     - docker run --rm -it -v `pwd`:/root/aula/ fisx/aula /bin/sh -c "/root/aula/travis/docker-list-sandbox-packages.sh"
+    - docker run --rm -it -v `pwd`:/root/aula/ fisx/aula /bin/sh -c "/root/aula/travis/docker-hlint.sh"
 
 script:
     - docker run --rm -it -v `pwd`:/root/aula/ fisx/aula /bin/sh -c "/root/aula/travis/docker-build.sh"

--- a/HLint.hs
+++ b/HLint.hs
@@ -1,0 +1,7 @@
+import "hlint" HLint.Default
+import "hlint" HLint.Dollar
+import "hlint" HLint.Generalise
+import "hlint" HLint.HLint
+
+ignore "Reduntant do"
+

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+HLINT=hlint
+FULL_SOURCES=-isrc -itests -i$(THENTOS_ROOT_PATH)/thentos-core/src/ -i$(THENTOS_ROOT_PATH)/thentos-tests/src/ -i$(THENTOS_ROOT_PATH)/thentos-tests/tests/
+
 .phony:
 
 # only aware of aula sources
 sensei: .phony
 	cabal exec -- sensei -isrc -itests tests/Spec.hs $(SENSEI_ARGS)
-
-FULL_SOURCES=-isrc -itests -i$(THENTOS_ROOT_PATH)/thentos-core/src/ -i$(THENTOS_ROOT_PATH)/thentos-tests/src/ -i$(THENTOS_ROOT_PATH)/thentos-tests/tests/
 
 # aware of aula and thentos sources
 sensei-full: .phony
@@ -27,3 +28,7 @@ click-dummies-refresh: .phony
 
 test-repl:
 	cabal exec -- ghci $(FULL_SOURCES)
+
+hlint:
+	$(HLINT) --version
+	find src exec -name '*.hs' | xargs $(HLINT)

--- a/travis/docker-hlint.sh
+++ b/travis/docker-hlint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh +e
+
+cd /root/aula
+make hlint
+
+exit 0


### PR DESCRIPTION
HLint checks are added to travis build. It won't break the build for the time being, until we figure out the common rules. Please contribute to `src/HLint.hs` or comment on this thread.