### PR TITLE
Api types

### DIFF
--- a/src/CreateRandom.hs
+++ b/src/CreateRandom.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeOperators     #-}
@@ -9,6 +10,7 @@ where
 
 import Data.Typeable (typeOf)
 import Data.Set (Set, insert)
+import Servant ((:>))
 import Test.QuickCheck (Arbitrary, generate, arbitrary)
 import Thentos.Prelude
 
@@ -16,6 +18,8 @@ import Action
 import Frontend.Core
 import Persistent
 import Types
+
+type CreateRandom a = "create_random" :> GetH (Frame (ST `Beside` PageShow a))
 
 -- | Create random entities that have 'MetaInfo' in the Aula Action monad.
 createRandom

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -121,9 +121,9 @@ type AulaSpace =
        -- browse wild ideas in an idea space
        "idea" :> GetH (Frame PageIdeasOverview)
        -- view idea details (applies to both wild ideas and ideas in topics)
-  :<|> "idea" :> Capture "idea" (AUID Idea) :> GetH (Frame PageTopicOverview)
+  :<|> "idea" :> Capture "idea" (AUID Idea) :> "view" :> GetH (Frame PageTopicOverview)
        -- edit idea (applies to both wild ideas and ideas in topics)
-  :<|> "idea" :> Capture "idea" (AUID Idea) :> FormH HTML (Html ()) Idea
+  :<|> "idea" :> Capture "idea" (AUID Idea) :> "edit" :> FormH HTML (Html ()) Idea
        -- create wild idea
   :<|> "idea" :> "create" :> FormH HTML (Html ()) ST
 

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -74,8 +74,7 @@ type FrontendH =
 type Aula =
        FrontendH
   :<|> "samples" :> Raw
-  :<|> Raw  -- FIXME: change this to @"static" :> Raw@
-            -- (@Raw@ on the empty path may accidentally process other end-points)
+  :<|> "static"  :> Raw
 
 aula :: (Action :~> ExceptT ServantErr IO) -> Server Aula
 aula (Nat runAction) =

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -42,7 +42,7 @@ runFrontend = do
     persist <- mkRunPersist
     let action = mkRunAction persist
     bootsrapDB persist -- FIXME: Remove Bootstrapping DB
-    runSettings settings . aulaTweaks $ serve (Proxy :: Proxy Aula) (aula (action UserLoggedOut))
+    runSettings settings . aulaTweaks $ serve (Proxy :: Proxy AulaTop) (aulaTop (action UserLoggedOut))
   where
     settings = setHost (fromString $ Config.config ^. listenerInterface)
              . setPort (Config.config ^. listenerPort)
@@ -57,14 +57,14 @@ runFrontend = do
 ----------------------------------------------------------------------
 -- driver
 
-type Aula =
-       FrontendH
+type AulaTop =
+       (AulaMain :<|> "testing" :> AulaTesting)
   :<|> "samples" :> Raw
   :<|> "static"  :> Raw
 
-aula :: (Action :~> ExceptT ServantErr IO) -> Server Aula
-aula (Nat runAction) =
-       enter runActionForceLogin frontendH
+aulaTop :: (Action :~> ExceptT ServantErr IO) -> Server AulaTop
+aulaTop (Nat runAction) =
+       enter runActionForceLogin (aulaMain :<|> aulaTesting)
   :<|> (\req cont -> getSamplesPath >>= \path -> serveDirectory path req cont)
   :<|> serveDirectory (Config.config ^. htmlStatic)
   where
@@ -74,7 +74,116 @@ aula (Nat runAction) =
         action
 
 
-type FrontendH =
+type AulaMain =
+       -- view all spaces
+       "space" :> GetH (Frame PageRoomsOverview)
+       -- enter one space
+  :<|> "space" :> Capture "space" ST :> AulaSpace
+
+       -- view all users
+  :<|> "user" :> GetH (PageShow [User])
+       -- enter user profile
+  :<|> "user" :> Capture "user" ST :> AulaUser
+
+       -- enter admin api
+  :<|> "admin" :> AulaAdmin
+
+       -- delegation network
+  :<|> "delegations" :> "edit" :> FormH HTML (Html ()) ()
+  :<|> "delegations" :> "view" :> GetH (Frame ST)
+
+       -- static content
+  :<|> "imprint" :> GetH (Frame PageStaticImprint)
+  :<|> "terms" :> GetH (Frame PageStaticTermsOfUse)
+
+       -- login
+  :<|> "login" :> FormH HTML (Html ()) ST
+
+
+aulaMain :: ServerT AulaMain Action
+aulaMain =
+       error "api not implemented: \"space\" :> GetH (Frame PageRoomsOverview)"
+  :<|> error "api not implemented: \"space\" :> Capture \"space\" ST :> AulaSpace"
+
+  :<|> error "api not implemented: \"user\"  :> GetH (PageShow [User])"
+  :<|> error "api not implemented: \"user\"  :> Capture \"user\" ST :> AulaUser"
+
+  :<|> error "api not implemented: \"admin\"  :> AulaAdmin"
+
+  :<|> error "api not implemented: \"delegations\" :> \"edit\" :> FormH HTML (Html ()) ()"
+  :<|> error "api not implemented: \"delegations\" :> \"view\" :> GetH (Frame ST)"
+
+  :<|> error "api not implemented: \"imprint\" :> GetH (Frame PageStaticImprint)"
+  :<|> error "api not implemented: \"terms\" :> GetH (Frame PageStaticTermsOfUse)"
+
+  :<|> error "api not implemented: \"login\" :> FormH HTML (Html ()) ST"
+
+
+type AulaSpace =
+       -- browse wild ideas in an idea space
+       "idea" :> GetH (Frame PageIdeasOverview)
+       -- view idea details (applies to both wild ideas and ideas in topics)
+  :<|> "idea" :> Capture "idea" (AUID Idea) :> GetH (Frame PageTopicOverview)
+       -- edit idea (applies to both wild ideas and ideas in topics)
+  :<|> "idea" :> Capture "idea" (AUID Idea) :> FormH HTML (Html ()) Idea
+       -- create wild idea
+  :<|> "idea" :> "create" :> FormH HTML (Html ()) ST
+
+       -- browse topics in an idea space
+  :<|> "topic" :> GetH (Frame PageIdeasInDiscussion)
+       -- view topic details (tabs "Alle Ideen", "Beauftragte Stimmen")
+  :<|> "topic" :> Capture "topic" (AUID Topic) :> "ideas"       :> GetH (Frame PageTopicOverview)
+  :<|> "topic" :> Capture "topic" (AUID Topic) :> "delegations" :> GetH (Frame PageTopicOverview)
+       -- create new topic
+  :<|> "topic" :> "create" :> FormH HTML (Html ()) ST
+       -- create new idea inside topic
+  :<|> "topic" :> "idea" :> "create" :> FormH HTML (Html ()) ST
+
+aulaSpace :: ServerT AulaSpace Action
+aulaSpace =
+       error "api not implemented: \"idea\"   :> GetH (Frame PageIdeasOverview)"
+  :<|> error "api not implemented: \"idea\"   :> Capture \"idea\" (AUID Idea) :> GetH (Frame PageTopicOverview)"
+  :<|> error "api not implemented: \"idea\"   :> Capture \"idea\" (AUID Idea) :> FormH HTML (Html ()) Idea"
+  :<|> error "api not implemented: \"idea\"   :> \"create\" :> FormH HTML (Html ()) ST"
+
+  :<|> error "api not implemented: \"topic\"  :> GetH (Frame PageIdeasInDiscussion)"
+  :<|> error "api not implemented: \"topic\"  :> Capture \"topic\" (AUID Topic) :> \"ideas\"       :> GetH (Frame PageTopicOverview)"
+  :<|> error "api not implemented: \"topic\"  :> Capture \"topic\" (AUID Topic) :> \"delegations\" :> GetH (Frame PageTopicOverview)"
+  :<|> error "api not implemented: \"topic\"  :> \"create\" :> FormH HTML (Html ()) ST"
+  :<|> error "api not implemented: \"topic\"  :> \"idea\" :> \"create\" :> FormH HTML (Html ()) ST"
+
+
+type AulaUser =
+       "ideas"       :> GetH (PageShow [Idea])
+  :<|> "delegations" :> GetH (PageShow [Delegation])
+  :<|> "settings"    :> GetH (Frame ST)
+
+aulaUser :: ServerT AulaUser Action
+aulaUser =
+       error "api not implemented: \"ideas\"       :> GetH (PageShow [Idea])"
+  :<|> error "api not implemented: \"delegations\" :> GetH (PageShow [Delegation])"
+  :<|> error "api not implemented: \"settings\"    :> GetH (Frame ST)"
+
+
+type AulaAdmin =
+       -- durations and quorum
+       "params" :> GetH (Frame ST)
+       -- groups and permissions
+  :<|> "access" :> GetH (Frame ST)
+       -- user creation and import
+  :<|> "user"   :> GetH (PageShow [Idea])
+       -- event log
+  :<|> "event"  :> GetH (PageShow [Idea])
+
+aulaAdmin :: ServerT AulaAdmin Action
+aulaAdmin =
+       error "api not implemented: \"params\" :> GetH (Frame ST)"
+  :<|> error "api not implemented: \"access\" :> GetH (Frame ST)"
+  :<|> error "api not implemented: \"user\"   :> GetH (PageShow [Idea])"
+  :<|> error "api not implemented: \"event\"  :> GetH (PageShow [Idea])"
+
+
+type AulaTesting =
        GetH (Frame ST)
   :<|> "ideaspaces" :> GetH (Frame PageRoomsOverview)
   :<|> "ideaspaces" :> CreateRandom IdeaSpace
@@ -91,8 +200,8 @@ type FrontendH =
   :<|> "imprint" :> GetH (Frame PageStaticImprint)
   :<|> "terms" :> GetH (Frame PageStaticTermsOfUse)
 
-frontendH :: ServerT FrontendH Action
-frontendH =
+aulaTesting :: ServerT AulaTesting Action
+aulaTesting =
        return (PublicFrame "yihaah!")
   :<|> (Frame frameUserHack . PageRoomsOverview <$> Action.persistent getSpaces)
   :<|> createRandomNoMeta dbSpaceSet

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -28,6 +28,10 @@ import Types
 
 import qualified Action
 
+
+----------------------------------------------------------------------
+-- driver
+
 -- FIXME: generate a proper user here, with real time stamp and AUID and everything.  no need to use
 -- arbitrary in 'bootstrapDB' below!
 adminUsernameHack :: ST
@@ -49,22 +53,9 @@ runFrontend = do
     bootsrapDB persist =
         generate arbitrary >>= void . bootstrapUser persist . (userLogin .~ adminUsernameHack)
 
-type FrontendH =
-       GetH (Frame ST)
-  :<|> "ideaspaces" :> GetH (Frame PageRoomsOverview)
-  :<|> "ideaspaces" :> CreateRandom IdeaSpace
-  :<|> "login" :> FormH HTML (Html ()) ST
-  :<|> "ideas" :> CreateRandom Idea
-  :<|> "ideas" :> GetH (Frame PageIdeasOverview)
-  :<|> "ideas" :> "create" :> FormH HTML (Html ()) ST
-  :<|> "users" :> CreateRandom User
-  :<|> "users" :> GetH (Frame (PageShow [User]))
-  :<|> "topics" :> CreateRandom Topic
-  :<|> "topics" :> GetH (Frame (PageShow [Topic]))
-  :<|> "topics" :> Capture "topic" (AUID Topic) :> GetH (Frame PageTopicOverview)
-  :<|> "topics" :> "create" :> FormH HTML (Html ()) ST
-  :<|> "imprint" :> GetH (Frame PageStaticImprint)
-  :<|> "terms" :> GetH (Frame PageStaticTermsOfUse)
+
+----------------------------------------------------------------------
+-- driver
 
 type Aula =
        FrontendH
@@ -81,6 +72,24 @@ aula (Nat runAction) =
     runActionForceLogin = Nat $ \action -> runAction $ do
         Action.login adminUsernameHack
         action
+
+
+type FrontendH =
+       GetH (Frame ST)
+  :<|> "ideaspaces" :> GetH (Frame PageRoomsOverview)
+  :<|> "ideaspaces" :> CreateRandom IdeaSpace
+  :<|> "login" :> FormH HTML (Html ()) ST
+  :<|> "ideas" :> CreateRandom Idea
+  :<|> "ideas" :> GetH (Frame PageIdeasOverview)
+  :<|> "ideas" :> "create" :> FormH HTML (Html ()) ST
+  :<|> "users" :> CreateRandom User
+  :<|> "users" :> GetH (Frame (PageShow [User]))
+  :<|> "topics" :> CreateRandom Topic
+  :<|> "topics" :> GetH (Frame (PageShow [Topic]))
+  :<|> "topics" :> Capture "topic" (AUID Topic) :> GetH (Frame PageTopicOverview)
+  :<|> "topics" :> "create" :> FormH HTML (Html ()) ST
+  :<|> "imprint" :> GetH (Frame PageStaticImprint)
+  :<|> "terms" :> GetH (Frame PageStaticTermsOfUse)
 
 frontendH :: ServerT FrontendH Action
 frontendH =

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -49,11 +49,6 @@ runFrontend = do
     bootsrapDB persist =
         generate arbitrary >>= void . bootstrapUser persist . (userLogin .~ adminUsernameHack)
 
-type GetH = Get '[HTML]
-
--- FIXME: this should be in module "CreateRandom".
-type CreateRandom a = "create_random" :> GetH (Frame (ST `Beside` PageShow a))
-
 type FrontendH =
        GetH (Frame ST)
   :<|> "ideaspaces" :> GetH (Frame PageRoomsOverview)

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -99,11 +99,12 @@ instance (ToHtml body) => ToHtml (Frame body) where
     toHtml (Frame usr bdy)   = pageFrame usr (toHtml bdy)
     toHtml (PublicFrame bdy) = publicPageFrame (toHtml bdy)
 
+-- | FIXME: share code better between 'pageFrame', 'pageFrame'', 'publicPageFrame'.
 publicPageFrame :: (Monad m) => HtmlT m a -> HtmlT m ()
 publicPageFrame bdy = do
     head_ $ do
         title_ "AuLA"
-        link_ [rel_ "stylesheet", href_ "/screen.css"]
+        link_ [rel_ "stylesheet", href_ "/static/screen.css"]
     body_ $ do
         publicHeaderMarkup >> bdy >> footerMarkup
 
@@ -114,7 +115,7 @@ pageFrame' :: (Monad m) => [HtmlT m a] -> User -> HtmlT m a -> HtmlT m ()
 pageFrame' extraHeaders usr bdy = do
     head_ $ do
         title_ "AuLA"
-        link_ [rel_ "stylesheet", href_ "/screen.css"]
+        link_ [rel_ "stylesheet", href_ "/static/screen.css"]
         sequence_ extraHeaders
     body_ $ do
         headerMarkup usr >> bdy >> footerMarkup

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE TypeFamilies         #-}
@@ -17,7 +18,7 @@ import Lucid
 import Lucid.Base
 import Network.Wai.Internal (Response(ResponseFile, ResponseBuilder, ResponseStream, ResponseRaw))
 import Network.Wai (Middleware)
-import Servant (ServerT)
+import Servant (ServerT, Get)
 import Servant.HTML.Lucid (HTML)
 import Servant.Missing (FormH, formRedirectH)
 import Text.Digestive.View
@@ -28,8 +29,8 @@ import Api
 import Types
 
 import qualified Data.Set as Set
-
 import qualified Text.Digestive.Form as DF
+
 
 -- | This will generate the following snippet:
 --
@@ -63,6 +64,8 @@ aulaTweaks app req cont = app req $ \resp -> do cont $ f resp
 
 ----------------------------------------------------------------------
 -- building blocks
+
+type GetH = Get '[HTML]
 
 -- | Render Form based Views
 class FormPageView p where

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -50,6 +50,8 @@ semanticDiv t = div_ [makeAttribute "data-aula-type" (cs . show . typeOf $ t)]
 -- 'Middleware' solves that.  (Alternatively, we could clone serveDirectory and solve the problem
 -- closer to its cause, but the current solution makes it easier to add other tweaks as the need
 -- arises.)
+--
+-- FIXME: rename to 'aulaMiddleware'?  'tweaks' explains nothing.
 aulaTweaks :: Middleware
 aulaTweaks app req cont = app req $ \resp -> do cont $ f resp
   where


### PR DESCRIPTION
- Give static content its own sub-directory.
- Refactor: move some primitive api types to more suitable modules.
- move existing end-points to /testing.
- add new api with all pages from click dummy.
- add handlers throwing "not implemented".

From here on, we can either work on the quick&dirty routing table as before, move features from there to the final application, or work on the latter from start.

I like servant!