### PR TITLE
Re-align hpack's package.yaml file with aula.cabal.

### DIFF
--- a/aula.cabal
+++ b/aula.cabal
@@ -124,6 +124,7 @@ executable aula-import-users
     , time
     , transformers
     , wai
+    , wai-app-static
     , warp
     , aula
     , nonce
@@ -173,6 +174,7 @@ executable aula-html-dummies
     , time
     , transformers
     , wai
+    , wai-app-static
     , warp
     , aula
     , extra
@@ -223,6 +225,7 @@ executable aula-server
     , time
     , transformers
     , wai
+    , wai-app-static
     , warp
     , aula
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ dependencies:
     - time
     - transformers
     - wai
+    - wai-app-static
     - warp
 
 library:


### PR DESCRIPTION
(@Mikolaj, you edited `aula.cabal` directly a few PRs back.  That works and can always be fixed later by someone else, as in this PR, but the better thing to do is edit `package.yaml` and call https://github.com/sol/hpack/ to generate the cabal file.)