### PR TITLE
Improve page-creator-howto

### DIFF
--- a/docs/page-creator-howto.md
+++ b/docs/page-creator-howto.md
@@ -4,10 +4,12 @@ We assume the environment is prepared as described in README.md
 under sections 'Getting started (with docker)' and 'HTML hacking'.
 
 Resources for page creators are gathered on Taiga
-(the clickdummy and textual descriptions of pages).
-A raw SVG file for the clickdummy is also available
-on request. Questions for the client can be asked
-on Taiga, as well.
+(the clickdummy and some related texts at
+https://tree.taiga.io/project/evpa-aula/us/20
+and https://tree.taiga.io/project/evpa-aula/us/25).
+A raw SVG file for the clickdummy is also available on request
+(and old version is at https://tree.taiga.io/project/evpa-aula/wiki/home).
+Questions for the client can be asked on Taiga, as well.
 
 For a list of html5 elements as they are available in the Haskell
 code, see
@@ -15,6 +17,10 @@ https://hackage.haskell.org/package/lucid-2.9.4/docs/Lucid-Html5.html.
 
 
 ## Improving pages under `samples/`
+
+An index of all pages known to the system is at <http://localhost:8080/samples>.
+Links from these pages point outside of `samples/`, but it's best to focus
+on the pages with sample data for initial development.
 
 Let's say I want to improve page
 
@@ -34,8 +40,9 @@ Once I make progress, I can record the change with
 git commit -a -m "Improve 001_PageRoomsOverview"`
 ```
 
-and switch the Haskell template code that generates this page,
+and switch to the Haskell template code that generates this page,
 which can be found via `git grep "ToHtml PageRoomsOverview"`
+(rarely it's something else than `ToHtml`; so ask around if `grep` fails)
 and turns out to reside in
 
 ```
@@ -44,25 +51,23 @@ src/Frontend/Page/Overview.hs
 
 After I tweak the `ToHtml` instance and save the file,
 the `click-dummies-refresh` utility running in another
-terminal automatically refreshes the HTML files
-and I can compare visually and with 'git diff' the result
-of the generation from the template with my previous manual
-tweaks to the HTML file.
+terminal automatically generates the HTML files afresh.
+At this point I can compare visually and with `git diff` the two versions:
+the result of the generation and my previous manually tweaked HTML.
 
 Occasionally, I may encounter the problem that I need some information
 from the system state that is not available in the current code
 for the `ToHtml` instance. In our running example, it means the value
 under the constructor `PageRoomsOverview` does not contain
 some information I would like to display on the page.
+I have two immediate options:
 
-Then I have two immediate options:
-
-1. Extend the type of `PageRoomsOverview`
+1. Extend the type of `PageRoomsOverview`.
 
 2. Fake it in the Haskell code, making up some literal values,
   or introducing local fake values (`where...`) in the `toHtml` function,
   with the intention of constructing them from the value under
-  constructor later on, when it's finally extended.
+  constructor later on, when it's extended.
 
 Both of these options are an improvement over faking values in the HTML files.
 
@@ -74,22 +79,27 @@ to fine-tune that without having to touch the generators in aula under
 `/src/Arbitrary.hs`, you can just edit the file with the name of your
 page and the ending `.hs`.
 
-If you do this, you will have to trigger sensei to refresh, because
-these files aren't watched.  You can trigger sensei either by touching
-any file in the aula repo, or by pressing `enter` in the sensei
-terminal.
+If you do this, you will have to trigger `click-dummies-refresh` to refresh,
+because these files aren't watched.  You can trigger `click-dummies-refresh`
+either by pressing `Enter` in its terminal or by touching any file
+in the aula repo.
 
-If you run into any issues with sensei, try to end (^D) and restart.
+If you run into any issues with `click-dummies-refresh`,
+try to end (^D) and restart.
 
 
 ## Creating new pages under `samples/`
 
-TODO: details
-
-I pick a page from the list, mark it as reserved for me,
-create a couple of empty files and a dummy `ToHtml` instance
-(the guys know where to put it) and a new, trivial page is ready
-for improvements, as described in the previous section.
+FIrst, pick a page from the clickdummy and note it down as reserved
+for you at https://tree.taiga.io/project/evpa-aula/us/20.
+Then create or extend a type definition for this page
+(such as `PageRoomsOverview` above; the guys know where to put it),
+add it to `/src/Arbitrary.hs`, `exec/RenderHtml.hs`
+and `tests/Frontend/HtmlSpec.hs`, create a dummy `ToHtml` instance
+(and/or other instances; ask around) and fight down any type errors.
+At this point the page should get listed at <http://localhost:8080/samples>.
+The page is trivial, but ready for further improvement, as described
+in section 'Improving pages under `samples/`'.
 
 
 ## Creating fully functional pages under `/` or `testing/`


### PR DESCRIPTION
I think, the instructions for pages under `samples/` are now fairly complete (whether accurate and up-to-date is another matter; please fix and update).