### PR TITLE
Frame refactor attempt - DO NOT MERGE

### DIFF
--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -11,13 +11,10 @@ module Frontend
 where
 
 import Control.Monad.Trans.Except
-import Lucid
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp (runSettings, setHost, setPort, defaultSettings)
 import Network.Wai.Application.Static (StaticSettings, ssRedirectToIndex, ssAddTrailingSlash, ssGetMimeType, defaultFileServerSettings, staticApp)
 import Servant
-import Servant.HTML.Lucid
-import Servant.Missing
 import System.FilePath (addTrailingPathSeparator)
 import Thentos.Prelude
 
@@ -96,12 +93,12 @@ type AulaMain =
        -- enter user profile
   :<|> "user" :> Capture "user" (AUID User) :> AulaUser
        -- user settings
-  :<|> "user" :> "settings" :> FormH HTML (Html ()) ()
+  :<|> "user" :> "settings" :> FormHandler ()
        -- enter admin api
   :<|> "admin" :> AulaAdmin
 
        -- delegation network
-  :<|> "delegation" :> "edit" :> FormH HTML (Html ()) ()
+  :<|> "delegation" :> "edit" :> FormHandler ()
   :<|> "delegation" :> "view" :> GetH (Frame ST)
 
        -- static content
@@ -109,7 +106,7 @@ type AulaMain =
   :<|> "terms" :> GetH (Frame PageStaticTermsOfUse)
 
        -- login
-  :<|> "login" :> FormH HTML (Html ()) ST
+  :<|> "login" :> FormHandler ST
 
 
 aulaMain :: ServerT AulaMain Action
@@ -122,7 +119,7 @@ aulaMain =
   :<|> Page.userSettings
   :<|> aulaAdmin
 
-  :<|> error "api not implemented: \"delegation\" :> \"edit\" :> FormH HTML (Html ()) ()"
+  :<|> error "api not implemented: \"delegation\" :> \"edit\" :> FormHandler ()"
   :<|> error "api not implemented: \"delegation\" :> \"view\" :> GetH (Frame ST)"
 
   :<|> pure (Frame frameUserHack PageStaticImprint) -- FIXME: Generate header with menu when the user is logged in.
@@ -137,9 +134,9 @@ type AulaSpace =
        -- view idea details (applies to both wild ideas and ideas in topics)
   :<|> "idea" :> Capture "idea" (AUID Idea) :> "view" :> GetH (Frame ViewIdea)
        -- edit idea (applies to both wild ideas and ideas in topics)
-  :<|> "idea" :> Capture "idea" (AUID Idea) :> "edit" :> FormH HTML (Html ()) Idea
+  :<|> "idea" :> Capture "idea" (AUID Idea) :> "edit" :> FormHandler Idea
        -- create wild idea
-  :<|> "idea" :> "create" :> FormH HTML (Html ()) ST
+  :<|> "idea" :> "create" :> FormHandler ST
 
        -- browse topics in an idea space
   :<|> "topic" :> GetH (Frame PageIdeasInDiscussion)
@@ -150,11 +147,11 @@ type AulaSpace =
   :<|> "topic" :> Capture "topic" (AUID Topic) :> "ideas" :> "winning" :> GetH (Frame ViewTopic)
   :<|> "topic" :> Capture "topic" (AUID Topic) :> "delegations"        :> GetH (Frame ViewTopic)
        -- create new topic
-  :<|> "topic" :> "create" :> FormH HTML (Html ()) ST
+  :<|> "topic" :> "create" :> FormHandler ST
        -- create new idea inside topic
-  :<|> "topic" :> Capture "topic" (AUID Topic) :> "idea" :> "create" :> FormH HTML (Html ()) ST
-  :<|> "topic" :> Capture "topic" (AUID Topic) :> "idea" :> "move"   :> FormH HTML (Html ()) ST
-  :<|> "topic" :> Capture "topic" (AUID Topic) :> "delegation" :> "create" :> FormH HTML (Html ()) ST
+  :<|> "topic" :> Capture "topic" (AUID Topic) :> "idea" :> "create" :> FormHandler ST
+  :<|> "topic" :> Capture "topic" (AUID Topic) :> "idea" :> "move"   :> FormHandler ST
+  :<|> "topic" :> Capture "topic" (AUID Topic) :> "delegation" :> "create" :> FormHandler ST
 
 aulaSpace :: IdeaSpace -> ServerT AulaSpace Action
 aulaSpace space =

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -54,6 +54,7 @@ semanticDiv t = div_ [makeAttribute "data-aula-type" (cs . show . typeOf $ t)]
 -- building blocks
 
 type GetH = Get '[HTML]
+type FormHandler a = FormH HTML (Html ()) a
 
 -- | Render Form based Views
 class FormPageView p where
@@ -226,7 +227,7 @@ redirectFormHandler
     :: (FormPageView p, Page p, RedirectOf p, ActionM m)
     => m p                       -- ^ Page representation
     -> (FormPageResult p -> m a) -- ^ Processor for the form result
-    -> ServerT (FormH HTML (Html ()) ST) m
+    -> ServerT (FormHandler ST) m
 redirectFormHandler getPage processor = formRedirectH' getPage makeForm p2 r
   where
     p2 page result = processor result $> absoluteUriPath (redirectOf page)

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -12,8 +12,10 @@ module Frontend.Core
 where
 
 import Control.Lens
+import Control.Monad (void)
 import Control.Monad.Except (MonadError, throwError)
 import Data.Functor (($>))
+import Data.Maybe (maybe)
 import Data.Set (Set)
 import Data.String.Conversions
 import Data.Typeable
@@ -55,6 +57,13 @@ semanticDiv t = div_ [makeAttribute "data-aula-type" (cs . show . typeOf $ t)]
 
 type GetH = Get '[HTML]
 type FormHandler a = FormH HTML (Html ()) a
+--type FormHandler a = FormH HTML FormHtml a
+
+newtype FormHtml = FormHtml (forall m . HtmlT m ())
+
+instance ToHtml FormHtml where
+    toHtml = toHtmlRaw
+    toHtmlRaw (FormHtml h) = h
 
 -- | Render Form based Views
 class FormPageView p where
@@ -62,7 +71,7 @@ class FormPageView p where
     -- | The form action used in form generation
     formAction :: p -> UriPath
     -- | Generates a Html view from the given page
-    makeForm :: (Monad m) => p -> DF.Form (Html ()) m (FormPageResult p)
+    makeForm :: (Monad m, Monad h) => p -> DF.Form (HtmlT h ()) m (FormPageResult p)
     -- | Generates a Html snippet from the given view, form action, and the @p@ page
     formPage :: (Monad m) => View (HtmlT m ()) -> ST -> p -> HtmlT m ()
 
@@ -192,50 +201,36 @@ instance ToHtml ListItemIdea where
                 if s == 1 then "Verbesserungsvorschlag" else "Verbesserungsvorschlaege"
             -- TODO: show how many votes are in and how many are required
 
--- FIXME: this is a temporary situation where we want to wait a conclusion on:
--- https://github.com/haskell-servant/servant/pull/391
--- before either:
--- * discarding formRedirectH' and use formRedirectH and before
--- * push this change towards Servant.Missing
--- * keep a version here
-formRedirectH' :: forall page payload m htm html.
-     (Monad m, MonadError ServantErr m, FormPageView page)
-  => m page
-  -> (page -> Form html m payload)           -- ^ processor1
-  -> (page -> payload -> m ST)               -- ^ processor2
-  -> (page -> View html -> ST -> m html)     -- ^ renderer
-  -> ServerT (FormH htm html payload) m
-formRedirectH' getPage processor1 processor2 renderer = getH :<|> postH
-  where
-    getH = do
-        page <- getPage
-        let fa = absoluteUriPath $ formAction page
-        v <- getForm fa (processor1 page)
-        renderer page v fa
-
-    postH env = do
-        page <- getPage
-        let fa = absoluteUriPath $ formAction page
-        (v, mpayload) <- postForm fa (processor1 page) (\_ -> return $ return . runIdentity . env)
-        case mpayload of
-            Just payload -> processor2 page payload >>= redirect
-            Nothing      -> renderer page v fa
-
-    redirect uri = throwError $ err303 { errHeaders = ("Location", cs uri) : errHeaders Servant.err303 }
-
 redirectFormHandler
     :: (FormPageView p, Page p, RedirectOf p, ActionM m)
     => m p                       -- ^ Page representation
     -> (FormPageResult p -> m a) -- ^ Processor for the form result
     -> ServerT (FormHandler ST) m
-redirectFormHandler getPage processor = formRedirectH' getPage makeForm p2 r
+redirectFormHandler getPage processor = getH :<|> postH
   where
-    p2 page result = processor result $> absoluteUriPath (redirectOf page)
-    r page v fa =
-        let frame = if isPrivatePage page
-              then pageFrame (Just frameUserHack)
-              else pageFrame Nothing in
-        pure . frame $ formPage v fa page
+    getH = do
+        page <- getPage
+        let fa = absoluteUriPath $ formAction page
+        v <- getForm fa (makeForm page)
+        pure $ formPage v fa page
+
+{-
+ghc: panic! (the 'impossible' happened)
+  (GHC version 7.10.3 for x86_64-unknown-linux):
+        No skolem info: m_a1hDB[sk]
+
+Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
+-}
+    -- postH :: _ -- GHC BUG
+    postH env = do
+        page <- getPage
+        let fa = absoluteUriPath $ formAction page
+        (v, mpayload) <- postForm fa (makeForm page) (\_ -> return $ return . runIdentity . env)
+        case mpayload of
+            Just payload -> (void $ processor payload) >> redirect (absoluteUriPath (redirectOf page))
+            Nothing      -> (pure $ formPage v fa page)
+
+    redirect uri = throwError $ err303 { errHeaders = ("Location", cs uri) : errHeaders Servant.err303 }
 
 ----------------------------------------------------------------------
 -- HACKS

--- a/src/Frontend/Page/Idea.hs
+++ b/src/Frontend/Page/Idea.hs
@@ -191,14 +191,14 @@ viewIdea _space ideaId = persistent $ do
 instance RedirectOf CreateIdea where
     redirectOf (CreateIdea space _) = relPath $ U.Space space U.ListIdeas
 
-createIdea :: ActionM m => IdeaSpace -> Maybe (AUID Topic) -> ServerT (FormH HTML (Html ()) ST) m
+createIdea :: ActionM m => IdeaSpace -> Maybe (AUID Topic) -> ServerT (FormHandler ST) m
 createIdea space mtopicId = redirectFormHandler (pure $ CreateIdea space mtopicId) (persistent . addIdea)
 
 instance RedirectOf EditIdea where
     redirectOf (EditIdea idea) = relPath $ U.Space (idea ^. ideaSpace) U.ListIdeas
 
 -- FIXME check _space
-editIdea :: ActionM m => IdeaSpace -> AUID Idea -> ServerT (FormH HTML (Html ()) ST) m
+editIdea :: ActionM m => IdeaSpace -> AUID Idea -> ServerT (FormHandler ST) m
 editIdea _space ideaId =
     redirectFormHandler
         (EditIdea . (\ (Just idea) -> idea) <$> persistent (findIdea ideaId))

--- a/src/Frontend/Page/Login.hs
+++ b/src/Frontend/Page/Login.hs
@@ -54,7 +54,7 @@ instance FormPageView PageHomeWithLoginPrompt where
 instance RedirectOf PageHomeWithLoginPrompt where
     redirectOf _ = relPath U.ListSpaces
 
-login :: (ActionM action) => ServerT (FormH HTML (Html ()) ST) action
+login :: (ActionM action) => ServerT (FormHandler ST) action
 login = redirectFormHandler (pure PageHomeWithLoginPrompt) makeUserLogin
   where
     makeUserLogin (LoginFormData user _pass) = Action.login user

--- a/src/Frontend/Page/Topic.hs
+++ b/src/Frontend/Page/Topic.hs
@@ -194,10 +194,10 @@ viewTopic _space tab topicId = persistent $ do
     ideas      <- findIdeasByTopic topic
     pure . makeFrame $ ViewTopicIdeas tab topic ideas
 
-createTopic :: (ActionM action) => IdeaSpace -> [AUID Idea] -> ServerT (FormH HTML (Html ()) ST) action
+createTopic :: (ActionM action) => IdeaSpace -> [AUID Idea] -> ServerT (FormHandler ST) action
 createTopic space ideas = redirectFormHandler (pure $ CreateTopic space ideas) (persistent . addTopic)
 
-moveIdeasToTopic :: ActionM m => IdeaSpace -> AUID Topic -> ServerT (FormH HTML (Html ()) ST) m
+moveIdeasToTopic :: ActionM m => IdeaSpace -> AUID Topic -> ServerT (FormHandler ST) m
 moveIdeasToTopic space topicId = redirectFormHandler getPage addIdeas
   where
     getPage = MoveIdeasToTopic space topicId <$> persistent (findWildIdeasBySpace space)

--- a/src/Frontend/Page/User.hs
+++ b/src/Frontend/Page/User.hs
@@ -64,7 +64,7 @@ instance FormPageView PageUserSettings where
 instance RedirectOf PageUserSettings where
     redirectOf _ = relPath U.ListSpaces
 
-userSettings :: (ActionM action) => ServerT (FormH HTML (Html ()) ST) action
+userSettings :: (ActionM action) => ServerT (FormHandler ST) action
 userSettings = redirectFormHandler (PageUserSettings <$> currentUser) changeUser
   where
     -- FIXME: Set the password

--- a/tests/Frontend/HtmlSpec.hs
+++ b/tests/Frontend/HtmlSpec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE ViewPatterns          #-}
 
-{-# OPTIONS_GHC -Wall -Werror -fno-warn-missing-signatures -fno-warn-incomplete-patterns #-}
+-- {-# OPTIONS_GHC -Wall -Werror -fno-warn-missing-signatures -fno-warn-incomplete-patterns #-}
 
 module Frontend.HtmlSpec where
 
@@ -29,6 +29,7 @@ import qualified Data.Text.Lazy as LT
 
 import Action
 import Arbitrary ()
+import Data.UriPath
 import Frontend.Page
 import Persistent
 import Types
@@ -168,7 +169,7 @@ renderForm :: FormGen -> Spec
 renderForm (F g) =
     it (show (typeOf g) <> " (show empty form)") . property . forAll g $ \page -> monadicIO $ do
         len <- run . failOnError $ do
-            v <- getForm (formAction page) (makeForm page)
+            v <- getForm (absoluteUriPath $ formAction page) (makeForm page)
             return . LT.length . renderText $ formPage v "formAction" page
         assert (len > 0)
 


### PR DESCRIPTION
**I create this to summarize my learnings**

Using `HTML` from the `Servant.Lucid` module forces us to use Identity monad in HtmlT but ToHtml instances forces us to use `HtmlT m ()` when we tackle with the Frame wrapping.