### PR TITLE
Redirect from `/` to `/space`.

### DIFF
--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -61,6 +61,7 @@ type AulaTop =
        (AulaMain :<|> "testing" :> AulaTesting)
   :<|> "samples" :> Raw
   :<|> "static"  :> Raw
+  :<|> GetH (Frame ())
 
 
 aulaTop :: (Action :~> ExceptT ServantErr IO) -> Server AulaTop
@@ -69,6 +70,7 @@ aulaTop (Nat runAction) =
   :<|> (\req cont -> getSamplesPath >>= \path ->
           waiServeDirectory path req cont)
   :<|> waiServeDirectory (Config.config ^. htmlStatic)
+  :<|> redirect "/space"
   where
     proxy :: Proxy (AulaMain :<|> "testing" :> AulaTesting)
     proxy = Proxy

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -56,12 +56,12 @@ import qualified Frontend.Path as P
 
 
 -- | FIXME: Could this be a PR for lucid?
-instance (ToHtml (HtmlT Identity ())) where
+instance ToHtml (HtmlT Identity ()) where
     toHtmlRaw = toHtml
     toHtml = HtmlT . return . runIdentity . runHtmlT
 
 -- | FIXME: Could this be a PR for lucid?
-instance (ToHtml ()) where
+instance ToHtml () where
     toHtmlRaw = toHtml
     toHtml = nil
 

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -18,7 +18,8 @@ import Data.UriPath
 import Types (AUID, User, Topic, Idea, IdeaSpace, nil)
 
 data Top =
-    TopMain Main
+    Top
+  | TopMain Main
   | TopTesting UriPath
   | TopSamples
   | TopStatic UriPath
@@ -26,6 +27,7 @@ data Top =
 instance HasPath Top where relPath = top
 
 top :: Top -> UriPath
+top Top            = nil
 top (TopMain p)    = relPath p
 top (TopTesting p) = nil </> "testing" <> p
 top TopSamples     = nil </> "samples"


### PR DESCRIPTION
- Export `redirect` from `Frontend.Core`.
- Add instance for `ToHtml ()`.
- Add path `Top -> "/"`.
- Add route `/` redirecting to `/space`.