### PR TITLE
Fixes for #193

### DIFF
--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -108,12 +108,17 @@ main :: IO ()
 main = run $ recreateSamples >> refreshSamples
 
 
+doGenerateDelegationNetworksHack :: Bool
+doGenerateDelegationNetworksHack = False
+
 -- | hspec test case: for the sensei loop
 spec :: Spec
 spec = do
     describe "refresh html samples" . it "works" . run $ refreshSamples
-    describe "render sample delegation graph" . it "works" . run $  -- TODO: not sure this should stay here.
-        fishDelegationNetworkIO >>= LBS.writeFile "/tmp/d3-aula-sample-fishes.json" . Aeson.encodePretty . D3DN
+    when doGenerateDelegationNetworksHack $ do
+        describe "render sample delegation graph" . it "works" . run $
+            fishDelegationNetworkIO >>=
+                LBS.writeFile "/tmp/d3-aula-sample-fishes.json" . Aeson.encodePretty . D3DN
 
 
 -- | set locale, target directory.  create target directory if missing.

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -697,7 +697,11 @@ mkFishUser (("http://zierfischverzeichnis.de/klassen/pisces/" <>) -> avatar) = d
         (userAvatar .~ avatar) <$> addUser (ProtoUser Nothing fnam lnam [role] Nothing Nothing)
 
 instance Arbitrary DelegationNetwork where
-    arbitrary = pure $ unsafePerformIO fishDelegationNetworkIO
+    arbitrary = pure fishDelegationNetworkUnsafe
+
+{-# NOINLINE fishDelegationNetworkUnsafe #-}
+fishDelegationNetworkUnsafe :: DelegationNetwork
+fishDelegationNetworkUnsafe = unsafePerformIO fishDelegationNetworkIO
 
 fishDelegationNetworkIO :: IO DelegationNetwork
 fishDelegationNetworkIO = do


### PR DESCRIPTION
(@Mikolaj you've reviewed #193, and we both forgot: wasn't there a problem with `unsafePerformaIO` inlining before?)