### PR TITLE
Make broken links actually break, not mysteriously re-direct to /spaces.

### DIFF
--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -36,7 +36,7 @@ instance HasPath Top where relPath = top
 
 top :: Top -> UriPath
 top Top            = nil
-top Broken         = nil
+top Broken         = "bröken"
 top (TopMain p)    = relPath p
 top (TopTesting p) = nil </> "testing" <> p
 top TopSamples     = nil </> "samples"


### PR DESCRIPTION
Very small PR, but very helpful!