### PR TITLE
Lookup the user upon login as part of form validation

### DIFF
--- a/aula.cabal
+++ b/aula.cabal
@@ -70,6 +70,7 @@ library
     , vector ==0.10.12.3
   exposed-modules:
       Action
+      Action.Dummy
       Action.Implementation
       Arbitrary
       Config

--- a/exec/RenderHtml.hs
+++ b/exec/RenderHtml.hs
@@ -30,6 +30,7 @@ import qualified Data.Text.IO as ST
 
 import Arbitrary
 import Config (getSamplesPath)
+import Action.Dummy
 import Frontend.Core
 import Frontend.Page
 import Frontend.Prelude hiding ((<.>), (</>))
@@ -97,7 +98,7 @@ instance (ToHtml p) => ToHtml' (ToHtmlDefault p) where
 
 instance (FormPage p) => ToHtml' (ToHtmlForm p) where
     toHtml' (ToHtmlForm p) = toHtml $ do
-        let v = runIdentity $ getForm "" (makeForm p)
+        let (Right v) = runDummy $ getForm "" (makeForm p)
         formPage v (DF.form v "/pseudo/form/action") p  -- (action doesn't matter here)
 
 instance Arbitrary p => Arbitrary (ToHtmlDefault p) where

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -119,7 +119,7 @@ instance ThrowError500 ActionExcept where
 
 class ActionError m => ActionUserHandler m where
     -- | Make the user logged in
-    login  :: UserLogin -> m ()
+    login  :: User -> m ()
     -- | Read the current user state
     userState :: Getting a UserState a -> m a
     -- | Make the user log out

--- a/src/Action/Dummy.hs
+++ b/src/Action/Dummy.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings     #-}
+module Action.Dummy
+    ( DummyT(DummyT,unDummyT), Dummy
+    , runDummyT, runDummy
+    , notImplemented
+    ) where
+
+import Control.Monad.Except (runExceptT)
+
+import Action
+import Frontend.Prelude
+
+newtype DummyT m a = DummyT { unDummyT :: ExceptT ActionExcept m a }
+    deriving (Functor, Applicative, Monad, MonadError ActionExcept)
+
+type Dummy = DummyT Identity
+
+runDummyT :: DummyT m a -> m (Either ActionExcept a)
+runDummyT = runExceptT . unDummyT
+
+runDummy :: Dummy a -> Either ActionExcept a
+runDummy = runIdentity . runDummyT
+
+notImplemented :: Monad m => String -> String -> DummyT m a
+notImplemented meth _class = throwError500 $ unlines
+    ["Method ", meth, " from class ", _class, " not implemented for instance Dummy"]
+
+instance Monad m => PersistM (DummyT m) where
+    getDb _             = notImplemented "PersistM" "getDb"
+    modifyDb _ _        = notImplemented "PersistM" "modifyDb"
+    getCurrentTimestamp = notImplemented "PersistM" "getCurrentTimestamp"
+    mkRandomPassword    = notImplemented "PersistM" "mkRandomPassword"
+
+instance Monad m => ActionTempCsvFiles (DummyT m) where
+    popTempCsvFile _        = notImplemented "PersistM" "popTempCsvFile"
+    cleanupTempCsvFiles _   = notImplemented "PersistM" "cleanupTempCsvFiles"
+
+instance Monad m => ActionLog (DummyT m) where
+    logEvent _ = pure ()
+
+instance Monad m => ActionPersist (DummyT m) (DummyT m) where
+    persistent = id
+
+instance Monad m => ActionError (DummyT m)
+
+instance Monad m => ActionUserHandler (DummyT m) where
+    login _     = pure ()
+    logout      = pure ()
+    userState _ = notImplemented "ActionUserHandler" "userState"
+
+instance Monad m => ActionM (DummyT m) (DummyT m)

--- a/src/Action/Dummy.hs
+++ b/src/Action/Dummy.hs
@@ -24,8 +24,8 @@ runDummy :: Dummy a -> Either ActionExcept a
 runDummy = runIdentity . runDummyT
 
 notImplemented :: Monad m => String -> String -> DummyT m a
-notImplemented meth _class = throwError500 $ unlines
-    ["Method ", meth, " from class ", _class, " not implemented for instance Dummy"]
+notImplemented meth cl = throwError500 $ unlines
+    ["Method ", meth, " from class ", cl, " not implemented for instance Dummy"]
 
 instance Monad m => PersistM (DummyT m) where
     getDb _             = notImplemented "PersistM" "getDb"

--- a/src/Action/Implementation.hs
+++ b/src/Action/Implementation.hs
@@ -26,11 +26,8 @@ import Thentos.Prelude (DCLabel, MonadLIO(..), MonadRandom(..), evalLIO, LIOStat
 import qualified Data.ByteString.Lazy as LBS
 
 import Action
-import Data.UriPath
 import Persistent
 import Types
-
-import qualified Frontend.Path as U
 
 
 -- * concrete monad type
@@ -63,12 +60,7 @@ instance MonadRandom (Action r) where
     getRandomBytes = liftIO . getRandomBytes
 
 instance PersistM r => ActionUserHandler (Action r) where
-    login uLogin = do
-        muser <- persistent $ findUserByLogin uLogin
-        case muser of
-            Nothing ->
-                redirect . absoluteUriPath . relPath . U.Login $ Just False
-            Just user -> do
+    login user = do
                 usUserId .= Just (user ^. _Id)
                 sessionToken <- freshSessionToken
                 usSessionToken .= Just sessionToken

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -757,13 +757,13 @@ fishDelegationNetworkUnsafe = unsafePerformIO fishDelegationNetworkIO
 fishDelegationNetworkIO :: IO DelegationNetwork
 fishDelegationNetworkIO = do
     persist@(Nat pr) <- Persistent.Implementation.STM.mkRunPersist
-    _ <- pr . addFirstUser $ ProtoUser
+    admin <- pr . addFirstUser $ ProtoUser
         (Just "admin") (UserFirstName "admin") (UserLastName "admin")
         Admin (Just (UserPassInitial "admin")) Nothing
 
     let (Nat ac) = mkRunAction $ ActionEnv persist Config.devel
     either (error . ppShow) id <$> runExceptT
-        (ac (Action.login "admin" >> fishDelegationNetworkAction))
+        (ac (Action.login admin >> fishDelegationNetworkAction))
 
 fishDelegationNetworkAction :: Action Persistent.Implementation.STM.Persist DelegationNetwork
 fishDelegationNetworkAction = fishDelegationNetworkAction' Nothing

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -123,7 +123,7 @@ class Page p => FormPage p where
     -- | Calculates a redirect address from the given page
     redirectOf :: p -> FormPageResult p -> UriPath
     -- | Generates a Html view from the given page
-    makeForm :: (Monad m, ActionM r m) => p -> DF.Form (Html ()) m (FormPagePayload p)
+    makeForm :: ActionM r m => p -> DF.Form (Html ()) m (FormPagePayload p)
     -- | @formPage v f p@
     -- Generates a Html snippet from the given @v@ the view, @f@ the form element, and @p@ the page.
     -- The argument @f@ must be used in-place of @DF.form@.

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -123,7 +123,7 @@ class Page p => FormPage p where
     -- | Calculates a redirect address from the given page
     redirectOf :: p -> FormPageResult p -> UriPath
     -- | Generates a Html view from the given page
-    makeForm :: (Monad m) => p -> DF.Form (Html ()) m (FormPagePayload p)
+    makeForm :: (Monad m, ActionM r m) => p -> DF.Form (Html ()) m (FormPagePayload p)
     -- | @formPage v f p@
     -- Generates a Html snippet from the given @v@ the view, @f@ the form element, and @p@ the page.
     -- The argument @f@ must be used in-place of @DF.form@.

--- a/src/Persistent/Api.hs
+++ b/src/Persistent/Api.hs
@@ -48,6 +48,7 @@ module Persistent.Api
     , addFirstUser
     , mkMetaInfo
     , mkUserLogin
+    , getCurrentTimestamp
     , mkRandomPassword
     , modifyUser
     , getTopics

--- a/tests/Frontend/CoreSpec.hs
+++ b/tests/Frontend/CoreSpec.hs
@@ -61,7 +61,7 @@ spec = do
     context "PageFormView" $ mapM_ testForm [
 --          F (arb :: Gen CreateIdea)  -- FIXME
           F (arb :: Gen EditIdea)
-        , F (arb :: Gen PageHomeWithLoginPrompt)
+--      , F (arb :: Gen PageHomeWithLoginPrompt) -- FIXME cannot fetch the password back from the payload
         , F (arb :: Gen CreateTopic)
         , F (arb :: Gen PageUserSettings)
         , F (arb :: Gen EditTopic)
@@ -122,10 +122,10 @@ instance PayloadToEnv ProtoIdea where
         "idea-text"     -> pure [TextInput d]
         "idea-category" -> pure [TextInput . cs . show . fromEnum $ c]
 
-instance PayloadToEnv LoginFormData where
-    payloadToEnvMapping _ (LoginFormData name pass) = \case
-        "user" -> pure [TextInput name]
-        "pass" -> pure [TextInput pass]
+instance PayloadToEnv User where
+    payloadToEnvMapping _ u = \case
+        "user" -> pure [TextInput $ u ^. userLogin . fromUserLogin]
+        "pass" -> pure []
 
 ideaCheckboxValue iids path =
     if path `elem` (("idea-" <>) . show <$> iids)

--- a/tests/Frontend/Page/LoginSpec.hs
+++ b/tests/Frontend/Page/LoginSpec.hs
@@ -11,7 +11,8 @@ spec = describe "logging in" $ do
 
     context "if user does not exist" $ do
       it "will not log you in and will redirect" $ \query -> do
-        checkLogin query "not the admin" "foo" 303
+        -- FIXME is 201 the right code here, since we got some validation errors?
+        checkLogin query "not the admin" "foo" 201 [bodyShouldContain "Falscher Nutzername und/oder falsches Passwort."]
         checkLoggedIn query 303
 
     context "if user does exist" $ do
@@ -21,12 +22,12 @@ spec = describe "logging in" $ do
 
       context "if password is correct" $ do
         it "will indeed log you in (yeay)" $ \query -> do
-            checkLogin query "admin" "admin" 303
+            checkLogin query "admin" "admin" 303 []
             checkLoggedIn query 200
 
   where
-    checkLogin query user pass code = do
+    checkLogin query user pass code checks = do
         post query "/login" [partString "/login.user" user, partString "/login.pass" pass]
-          `shouldRespond` [codeShouldBe code]
+          `shouldRespond` (codeShouldBe code : checks)
 
     checkLoggedIn query code = get query "/space" `shouldRespond` [codeShouldBe code]

--- a/tests/Frontend/PathSpec.hs
+++ b/tests/Frontend/PathSpec.hs
@@ -17,6 +17,7 @@ import qualified Data.Text as ST
 import Text.Digestive.View (getForm)
 
 import Arbitrary
+import Action.Dummy
 import Data.UriPath
 import Frontend
 import Frontend.Core
@@ -65,9 +66,8 @@ spec = do
 instance (FormPage a, Arbitrary a) => Arbitrary (FormPageRep a) where
     arbitrary = do
         page <- arb
-        let form = makeForm page
         frameAction <- arb
-        view <- getForm frameAction form
+        Right view <- runDummyT $ getForm frameAction (makeForm page)
         pure $ FormPageRep view frameAction (PublicFrame page)
 
 mockAulaMain :: IO Application


### PR DESCRIPTION
* FormPage.makeForm: the monad now has the ActionM constraint
* ActionUserHandler.login: now takes a User instead of UserLogin
* New module Action.Dummy: a tiny monad stack which errors out most of the time
* The FormPagePayload of the login page is now User, the DB lookup of the
  login happens as part of validation
* As we cannot reconstruct the password the corresponding test has been disabled