### PR TITLE
Introduce rest api for delegation network queries.

### DIFF
--- a/aula.cabal
+++ b/aula.cabal
@@ -74,6 +74,7 @@ library
       Action.Dummy
       Action.Implementation
       Arbitrary
+      Backend
       Config
       CreateRandom
       Data.UriPath
@@ -283,6 +284,7 @@ test-suite spec
   other-modules:
       AllModulesSpec
       AulaTests
+      BackendSpec
       Frontend.CoreSpec
       Frontend.Page.FileUploadSpec
       Frontend.Page.LoginSpec

--- a/src/Backend.hs
+++ b/src/Backend.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module Backend
+where
+
+import Action
+import Arbitrary
+import Servant
+import Types
+
+
+-- * rest api
+
+type Api = "delegations" :> DelegationsApi
+
+api :: (GenArbitrary r, ActionM r m) => ServerT Api m
+api = delegationsApi
+
+
+-- * delegations
+
+type DelegationsApi = Get '[JSON] DelegationNetwork
+
+-- | FIXME: This is all a bit silly: the new end-point logs in admin implicitly; the returned
+-- delegation networks are generated on top of the existing data; testing doesn't really test
+-- anything.  But it is self-contained and a good basis to continue from.
+delegationsApi :: (GenArbitrary r, ActionM r m) => ServerT Api m
+delegationsApi = Action.loginByName "admin" >> fishDelegationNetworkAction

--- a/src/Persistent/Implementation/STM.hs
+++ b/src/Persistent/Implementation/STM.hs
@@ -22,7 +22,7 @@ import Types
 import Persistent.Api
 
 -- FIXME: Remove
-import Test.QuickCheck (generate, arbitrary)
+import Test.QuickCheck (generate)
 
 newtype Persist a = Persist (ReaderT (TVar AulaData) IO a)
   deriving (Functor, Applicative, Monad)
@@ -31,7 +31,7 @@ persistIO :: IO a -> Persist a
 persistIO = Persist . liftIO
 
 instance GenArbitrary Persist where
-    genArbitrary = persistIO $ generate arbitrary
+    genGen = persistIO . generate
 
 mkRunPersist :: IO (Persist :~> IO)
 mkRunPersist = do

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -35,7 +35,7 @@ import qualified Database.PostgreSQL.Simple.ToField as PostgreSQL
 import qualified Data.Csv as CSV
 import qualified Generics.SOP as SOP
 
-import Test.QuickCheck (Arbitrary)
+import Test.QuickCheck (Gen, Arbitrary, arbitrary)
 
 
 -- * a small prelude
@@ -477,7 +477,11 @@ timestampFormatLength = length ("1864-04-13_13:01:33_846177415049" :: String)
 
 -- | FIXME: should either go to the test suite or go away completely.
 class Monad m => GenArbitrary m where
-    genArbitrary :: Arbitrary a => m a
+    genGen :: Gen a -> m a
+
+-- | FIXME: should either go to the test suite or go away completely.
+genArbitrary :: (GenArbitrary m, Arbitrary a) => m a
+genArbitrary = genGen arbitrary
 
 
 -- * admin pages

--- a/tests/BackendSpec.hs
+++ b/tests/BackendSpec.hs
@@ -1,0 +1,11 @@
+module BackendSpec where
+
+import AulaTests
+
+spec :: Spec
+spec = do
+    describe "delegation graph" . around withServer $ do
+        it "responds" $ \query -> do
+            get query "/api/delegations" `shouldRespond` [codeShouldBe 200]
+        it "body contains delegation network" $ \query -> do
+            pending

--- a/tests/BackendSpec.hs
+++ b/tests/BackendSpec.hs
@@ -7,5 +7,5 @@ spec = do
     describe "delegation graph" . around withServer $ do
         it "responds" $ \query -> do
             get query "/api/delegations" `shouldRespond` [codeShouldBe 200]
-        it "body contains delegation network" $ \query -> do
+        it "body contains delegation network" $ \_query -> do
             pending


### PR DESCRIPTION
- Add Backend module and export fish sample networks.
- Allow GenArbitrary to run `Gen` actions.
- Make handler types and fish sample network generation more polymorphic.

This is all a bit silly: the new end-point logs in admin implicitly; the returned delegation networks are generated on top of the existing data; testing doesn't really test anything.  But it is self-contained and a good basis to continue from.