### PR TITLE
Persist vs. Except

### DIFF
--- a/src/Action.hs
+++ b/src/Action.hs
@@ -80,7 +80,7 @@ userLoggedOut :: UserState
 userLoggedOut = UserState Nothing Nothing Nothing
 
 data ActionEnv r = ActionEnv
-    { _persistNat :: r :~> ExceptT ServantErr IO
+    { _persistNat :: r :~> ExceptT PersistExcept IO
     , _config     :: Config
     }
 
@@ -90,6 +90,9 @@ instance GetCsrfSecret (ActionEnv r) where
     csrfSecret = config . csrfSecret
 
 -- | Top level errors can happen.
+--
+-- FIXME: this will have a constructor dedicated for PersistExcept, and 'ServantErr' will only be
+-- introduced later.
 newtype ActionExcept = ActionExcept { unActionExcept :: ServantErr }
     deriving (Eq, Show)
 

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeOperators          #-}
+
 -- | The 'Action' module contains an API which
 module Action
     ( -- * constraint types
@@ -88,7 +89,6 @@ instance GetCsrfSecret (ActionEnv r) where
     csrfSecret = config . csrfSecret
 
 -- | Top level errors can happen.
---
 newtype ActionExcept = ActionExcept { unActionExcept :: ServantErr }
     deriving (Eq, Show)
 

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -46,6 +46,7 @@ where
 import Control.Lens
 import Control.Monad (void)
 import Control.Monad.Except (MonadError)
+import Control.Monad.Trans.Except (ExceptT(ExceptT))
 import Data.Char (ord)
 import Data.Maybe (isJust)
 import Data.String.Conversions (ST, LBS)
@@ -79,7 +80,7 @@ userLoggedOut :: UserState
 userLoggedOut = UserState Nothing Nothing Nothing
 
 data ActionEnv r = ActionEnv
-    { _persistNat :: r :~> IO
+    { _persistNat :: r :~> ExceptT ServantErr IO
     , _config     :: Config
     }
 
@@ -110,7 +111,7 @@ class Monad m => ActionLog m where
 -- @r@ is determined by @m@, because @m@ is intended to be the program's
 -- action monad, so @r@ is just the persistent implementation chosen
 -- to be used in the action monad.
-class (PersistM r, Monad m) => ActionPersist r m | m -> r where
+class (PersistM r, Monad m, MonadError ActionExcept m) => ActionPersist r m | m -> r where
     -- | Run @Persist@ computation in the action monad.
     -- Authorization of the action should happen here.
     -- FIXME: Rename atomically, and only call on

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -46,7 +46,7 @@ where
 import Control.Lens
 import Control.Monad (void)
 import Control.Monad.Except (MonadError)
-import Control.Monad.Trans.Except (ExceptT(ExceptT))
+import Control.Monad.Trans.Except (ExceptT)
 import Data.Char (ord)
 import Data.Maybe (isJust)
 import Data.String.Conversions (ST, LBS)

--- a/src/Action/Dummy.hs
+++ b/src/Action/Dummy.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
 module Action.Dummy
-    ( DummyT(DummyT,unDummyT), Dummy
+    ( DummyT(DummyT, unDummyT), Dummy
     , runDummyT, runDummy
     , notImplemented
     ) where
@@ -11,6 +12,7 @@ import Control.Monad.Except (runExceptT)
 
 import Action
 import Frontend.Prelude
+
 
 newtype DummyT m a = DummyT { unDummyT :: ExceptT ActionExcept m a }
     deriving (Functor, Applicative, Monad, MonadError ActionExcept)
@@ -34,8 +36,8 @@ instance Monad m => PersistM (DummyT m) where
     mkRandomPassword    = notImplemented "PersistM" "mkRandomPassword"
 
 instance Monad m => ActionTempCsvFiles (DummyT m) where
-    popTempCsvFile _        = notImplemented "PersistM" "popTempCsvFile"
-    cleanupTempCsvFiles _   = notImplemented "PersistM" "cleanupTempCsvFiles"
+    popTempCsvFile _      = notImplemented "PersistM" "popTempCsvFile"
+    cleanupTempCsvFiles _ = notImplemented "PersistM" "cleanupTempCsvFiles"
 
 instance Monad m => ActionLog (DummyT m) where
     logEvent _ = pure ()

--- a/src/Action/Dummy.hs
+++ b/src/Action/Dummy.hs
@@ -11,6 +11,7 @@ module Action.Dummy
 import Control.Monad.Except (runExceptT)
 
 import Action
+import Persistent.Implementation.STM (Persist)
 import Frontend.Prelude
 
 
@@ -29,12 +30,6 @@ notImplemented :: Monad m => String -> String -> DummyT m a
 notImplemented meth cl = throwError500 $ unlines
     ["Method ", meth, " from class ", cl, " not implemented for instance Dummy"]
 
-instance Monad m => PersistM (DummyT m) where
-    getDb _             = notImplemented "PersistM" "getDb"
-    modifyDb _ _        = notImplemented "PersistM" "modifyDb"
-    getCurrentTimestamp = notImplemented "PersistM" "getCurrentTimestamp"
-    mkRandomPassword    = notImplemented "PersistM" "mkRandomPassword"
-
 instance Monad m => ActionTempCsvFiles (DummyT m) where
     popTempCsvFile _      = notImplemented "PersistM" "popTempCsvFile"
     cleanupTempCsvFiles _ = notImplemented "PersistM" "cleanupTempCsvFiles"
@@ -42,8 +37,8 @@ instance Monad m => ActionTempCsvFiles (DummyT m) where
 instance Monad m => ActionLog (DummyT m) where
     logEvent _ = pure ()
 
-instance Monad m => ActionPersist (DummyT m) (DummyT m) where
-    persistent = id
+instance Monad m => ActionPersist Persist (DummyT m) where
+    persistent _ = notImplemented "ActionPersist" "persistent"
 
 instance Monad m => ActionError (DummyT m)
 
@@ -52,4 +47,4 @@ instance Monad m => ActionUserHandler (DummyT m) where
     logout      = pure ()
     userState _ = notImplemented "ActionUserHandler" "userState"
 
-instance Monad m => ActionM (DummyT m) (DummyT m)
+instance Monad m => ActionM Persist (DummyT m)

--- a/src/Action/Implementation.hs
+++ b/src/Action/Implementation.hs
@@ -53,7 +53,7 @@ instance PersistM r => ActionPersist r (Action r) where
     persistent r = do
         Nat rp <- view persistNat
         v  <- liftIO . runExceptT . rp $ r
-        either (throwError . ActionExcept) pure v  -- TODO: is this strict enough?  how can we test this?
+        either (throwError . ActionExcept . unPersistExcept) pure v  -- TODO: is this strict enough?  how can we test this?
 
 instance MonadLIO DCLabel (Action r) where
     liftLIO = liftIO . (`evalLIO` LIOState dcBottom dcBottom)

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -31,10 +31,11 @@ module Arbitrary
     ) where
 
 import Control.Applicative ((<**>))
+import Control.Exception (ErrorCall(ErrorCall), throwIO)
 import Control.Lens (set, (^.))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad (replicateM)
-import Control.Monad.Trans.Except (runExceptT)
+import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Data.Aeson as Aeson
 import Data.Char
 import Data.List as List
@@ -765,16 +766,19 @@ fishDelegationNetworkUnsafe = unsafePerformIO fishDelegationNetworkIO
 
 fishDelegationNetworkIO :: IO DelegationNetwork
 fishDelegationNetworkIO = do
-    cfg <- Config.getConfig Config.DontWarnMissing
+    let action :: Action Persistent.Implementation.STM.Persist DelegationNetwork
+        action = do
+            admin <- persistent . addFirstUser $ ProtoUser
+                (Just "admin") (UserFirstName "admin") (UserLastName "admin")
+                Admin (Just (UserPassInitial "admin")) Nothing
+            Action.loginByUser admin
+            fishDelegationNetworkAction
 
-    persist@(Nat pr) <- Persistent.Implementation.STM.mkRunPersist
-    admin <- pr . addFirstUser $ ProtoUser
-        (Just "admin") (UserFirstName "admin") (UserLastName "admin")
-        Admin (Just (UserPassInitial "admin")) Nothing
-
-    let (Nat ac) = mkRunAction $ ActionEnv persist cfg
-    either (error . ppShow) id <$> runExceptT
-        (ac (Action.loginByUser admin >> fishDelegationNetworkAction))
+    cfg     <- Config.getConfig Config.DontWarnMissing
+    persist <- Persistent.Implementation.STM.mkRunPersist
+    v :: Either ServantErr DelegationNetwork
+            <- runExceptT $ unNat (mkRunAction (ActionEnv persist cfg)) action
+    either (throwIO . ErrorCall . ppShow) pure v
 
 fishDelegationNetworkAction :: (GenArbitrary r, ActionM r m) => m DelegationNetwork
 fishDelegationNetworkAction = fishDelegationNetworkAction' Nothing

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -35,7 +35,7 @@ import Control.Exception (ErrorCall(ErrorCall), throwIO)
 import Control.Lens (set, (^.))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad (replicateM)
-import Control.Monad.Trans.Except (ExceptT, runExceptT)
+import Control.Monad.Trans.Except (runExceptT)
 import Data.Aeson as Aeson
 import Data.Char
 import Data.List as List

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -68,11 +68,12 @@ runFrontend cfg = do
     app <- serveFAction (Proxy :: Proxy AulaActions) stateProxy extendClearanceOnSessionToken
             runAction aulaActions
 
-    unNat persist genInitialTestDb -- FIXME: Remove Bootstrapping DB
+    Right _ <- runExceptT $ unNat persist genInitialTestDb -- FIXME: Remove Bootstrapping DB
 
     when (cfg ^. generateDemoData) $ do
         demoDataGen <- mkUniverse
-        unNat persist demoDataGen
+        Right _ <- runExceptT $ unNat persist demoDataGen
+        return ()
 
     -- Note that no user is being logged in anywhere here.
     runSettings settings . catch404 . serve aulaTopProxy $ aulaTop cfg app

--- a/src/Persistent/Api.hs
+++ b/src/Persistent/Api.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DefaultSignatures           #-}
+{-# LANGUAGE FlexibleContexts            #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE ImpredicativeTypes          #-}
 {-# LANGUAGE OverloadedStrings           #-}
@@ -83,6 +84,7 @@ module Persistent.Api
 where
 
 import Control.Lens
+import Control.Monad.Error.Class (MonadError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad (unless, replicateM, when)
 import Data.Elocrypt (mkPassword)
@@ -92,6 +94,7 @@ import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.String.Conversions (ST, cs, (<>))
 import Data.Time.Clock (getCurrentTime)
+import Servant (ServantErr)
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -136,7 +139,7 @@ dbTopics = dbTopicMap . to Map.elems
 emptyAulaData :: AulaData
 emptyAulaData = AulaData nil nil nil nil nil 21 21 30 3 0
 
-class Monad m => PersistM m where
+class (MonadError ServantErr m, Monad m) => PersistM m where
     getDb :: AulaGetter a -> m a
     modifyDb :: AulaSetter a -> (a -> a) -> m ()
 

--- a/src/Persistent/Api.hs
+++ b/src/Persistent/Api.hs
@@ -17,6 +17,7 @@ module Persistent.Api
     , AulaLens
     , AulaGetter
     , AulaSetter
+    , PersistExcept(PersistExcept, unPersistExcept)
 
     , AulaData
     , emptyAulaData
@@ -139,7 +140,12 @@ dbTopics = dbTopicMap . to Map.elems
 emptyAulaData :: AulaData
 emptyAulaData = AulaData nil nil nil nil nil 21 21 30 3 0
 
-class (MonadError ServantErr m, Monad m) => PersistM m where
+-- | FIXME: this will have constructors dedicated for specific errors, and 'ServantErr' will only be
+-- introduced later.
+newtype PersistExcept = PersistExcept { unPersistExcept :: ServantErr }
+    deriving (Eq, Show)
+
+class (MonadError PersistExcept m, Monad m) => PersistM m where
     getDb :: AulaGetter a -> m a
     modifyDb :: AulaSetter a -> (a -> a) -> m ()
 

--- a/src/Persistent/Implementation/STM.hs
+++ b/src/Persistent/Implementation/STM.hs
@@ -15,7 +15,10 @@ where
 import Control.Concurrent.STM (TVar, atomically, newTVarIO, readTVar, modifyTVar')
 import Control.Lens
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Trans.Except (ExceptT(ExceptT), runExceptT)
 import Control.Monad.Trans.Reader (ReaderT(ReaderT), runReaderT)
+import Servant (ServantErr)
 import Servant.Server ((:~>)(Nat))
 
 import Types
@@ -24,8 +27,8 @@ import Persistent.Api
 -- FIXME: Remove
 import Test.QuickCheck (generate)
 
-newtype Persist a = Persist (ReaderT (TVar AulaData) IO a)
-  deriving (Functor, Applicative, Monad)
+newtype Persist a = Persist (ExceptT ServantErr (ReaderT (TVar AulaData) IO) a)
+  deriving (Functor, Applicative, Monad, MonadError ServantErr)
 
 persistIO :: IO a -> Persist a
 persistIO = Persist . liftIO
@@ -33,15 +36,20 @@ persistIO = Persist . liftIO
 instance GenArbitrary Persist where
     genGen = persistIO . generate
 
-mkRunPersist :: IO (Persist :~> IO)
+mkRunPersist :: IO (Persist :~> ExceptT ServantErr IO)
 mkRunPersist = do
     tvar <- newTVarIO emptyAulaData
-    let run (Persist c) = c `runReaderT` tvar
+    let run (Persist c) = ExceptT $ runExceptT c `runReaderT` tvar
     return $ Nat run
 
-instance MonadIO Persist where
+instance MonadIO Persist where  -- TODO: get rid of this.  use persistIO if we must.
     liftIO = persistIO
 
 instance PersistM Persist where
-    getDb l = Persist . ReaderT $ fmap (view l) . atomically . readTVar
-    modifyDb l f = Persist . ReaderT $ \state -> atomically $ modifyTVar' state (l %~ f)
+    getDb l = Persist . ExceptT . ReaderT $
+        fmap (Right . view l) . atomically . readTVar
+    modifyDb l f = Persist . ExceptT . ReaderT $
+        \state -> fmap Right . atomically $ modifyTVar' state (l %~ f)
+
+-- TODO: we want tests for all of this!
+-- TODO: newtype PersistExcept similar to ActionExcept

--- a/src/Persistent/Implementation/STM.hs
+++ b/src/Persistent/Implementation/STM.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables         #-}
 {-# LANGUAGE TypeOperators               #-}
 
-{-# OPTIONS_GHC -Wall -Werror -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
 
 module Persistent.Implementation.STM
     ( Persist

--- a/src/Persistent/Implementation/STM.hs
+++ b/src/Persistent/Implementation/STM.hs
@@ -18,7 +18,6 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Error.Class (MonadError)
 import Control.Monad.Trans.Except (ExceptT(ExceptT), runExceptT)
 import Control.Monad.Trans.Reader (ReaderT(ReaderT), runReaderT)
-import Servant (ServantErr)
 import Servant.Server ((:~>)(Nat))
 
 import Types
@@ -27,8 +26,8 @@ import Persistent.Api
 -- FIXME: Remove
 import Test.QuickCheck (generate)
 
-newtype Persist a = Persist (ExceptT ServantErr (ReaderT (TVar AulaData) IO) a)
-  deriving (Functor, Applicative, Monad, MonadError ServantErr)
+newtype Persist a = Persist (ExceptT PersistExcept (ReaderT (TVar AulaData) IO) a)
+  deriving (Functor, Applicative, Monad, MonadError PersistExcept)
 
 persistIO :: IO a -> Persist a
 persistIO = Persist . liftIO
@@ -36,7 +35,7 @@ persistIO = Persist . liftIO
 instance GenArbitrary Persist where
     genGen = persistIO . generate
 
-mkRunPersist :: IO (Persist :~> ExceptT ServantErr IO)
+mkRunPersist :: IO (Persist :~> ExceptT PersistExcept IO)
 mkRunPersist = do
     tvar <- newTVarIO emptyAulaData
     let run (Persist c) = ExceptT $ runExceptT c `runReaderT` tvar

--- a/tests/Frontend/PathSpec.hs
+++ b/tests/Frontend/PathSpec.hs
@@ -65,13 +65,13 @@ spec = do
     mainGen = arbitrary
 
 
--- Each path has a handler
+-- * Each path has a handler
 
 instance (FormPage a, Arbitrary a) => Arbitrary (FormPageRep a) where
     arbitrary = do
-        page <- arb
+        page        <- arb
         frameAction <- arb
-        Right view <- runDummyT $ getForm frameAction (makeForm page)
+        Right view  <- runDummyT $ getForm frameAction (makeForm page)
         pure $ FormPageRep view frameAction (PublicFrame page)
 
 mockAulaMain :: IO Application


### PR DESCRIPTION
This introduces exceptions for PersistM in a minimal way.

The next step would be to change the types `ActionExcept` and `PersistExcept` as indicated in the resp. FIXMEs.