### PR TITLE
Restrict spaces to the current user

### DIFF
--- a/src/Action.hs
+++ b/src/Action.hs
@@ -267,8 +267,13 @@ validUserState us = us == userLoggedOut || validLoggedIn us
 
 getSpacesForCurrentUser :: (ActionUserHandler m, ActionPersist m) => m [IdeaSpace]
 getSpacesForCurrentUser = do
-    user <- currentUser
-    query $ getSpacesForRole (user ^. userRole)
+    -- FIXME: remove the isLoggedIn check.
+    b <- isLoggedIn
+    if b then do
+        user <- currentUser
+        query $ getSpacesForRole (user ^. userRole)
+    else
+        pure []
 
 -- * Phase Transitions
 

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -36,6 +36,7 @@ module Action
     , isLoggedIn
     , validUserState
     , validLoggedIn
+    , getSpacesForCurrentUser
 
       -- * user state
     , UserState(..), usUserId, usCsrfToken, usSessionToken
@@ -264,6 +265,10 @@ validLoggedIn us = isJust (us ^. usUserId) && isJust (us ^. usSessionToken)
 validUserState :: UserState -> Bool
 validUserState us = us == userLoggedOut || validLoggedIn us
 
+getSpacesForCurrentUser :: (ActionUserHandler m, ActionPersist m) => m [IdeaSpace]
+getSpacesForCurrentUser = do
+    user <- currentUser
+    query $ getSpacesForRole (user ^. userRole)
 
 -- * Phase Transitions
 

--- a/src/Frontend/Page/Overview.hs
+++ b/src/Frontend/Page/Overview.hs
@@ -53,7 +53,7 @@ data ActiveTab = WildIdeas | Topics
 
 viewRooms :: (ActionPersist m, ActionUserHandler m, MonadError ActionExcept m)
     => m (Frame PageRoomsOverview)
-viewRooms = makeFrame =<< (PageRoomsOverview <$> query getSpaces)
+viewRooms = makeFrame =<< (PageRoomsOverview <$> getSpacesForCurrentUser)
 
 viewIdeas :: (ActionPersist m, ActionUserHandler m, MonadError ActionExcept m)
     => IdeaSpace -> IdeasFilterQuery -> m (Frame PageIdeasOverview)

--- a/src/Persistent/Pure.hs
+++ b/src/Persistent/Pure.hs
@@ -50,6 +50,7 @@ module Persistent.Pure
     , maybe404
 
     , getSpaces
+    , getSpacesForRole
     , getIdeas
     , getWildIdeas
     , getIdeasWithTopic
@@ -439,6 +440,12 @@ getSchoolClasses = mapMaybe toClass <$> getSpaces
   where
     toClass (ClassSpace clss) = Just clss
     toClass SchoolSpace       = Nothing
+
+getSpacesForRole :: Role -> Query [IdeaSpace]
+getSpacesForRole role =
+    case role ^? roleSchoolClass of
+        Just clss -> findAllIn dbSpaces (`elem` [SchoolSpace, ClassSpace clss])
+        Nothing   -> getSpaces
 
 getTopics :: Query [Topic]
 getTopics = view dbTopics

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -470,8 +470,8 @@ instance SOP.Generic ProtoUser
 -- | Note that all roles except 'Student' and 'ClassGuest' have the same access to all IdeaSpaces.
 -- (Rationale: e.g. teachers have trust each other and can cover for each other.)
 data Role =
-    Student    { _studentSchoolClass :: SchoolClass }
-  | ClassGuest { _guestSchoolClass   :: SchoolClass } -- ^ e.g., parents
+    Student    { _roleSchoolClass :: SchoolClass }
+  | ClassGuest { _roleSchoolClass :: SchoolClass } -- ^ e.g., parents
   | SchoolGuest  -- ^ e.g., researchers
   | Moderator
   | Principal


### PR DESCRIPTION
* Change: use getSpacesForCurrentUser in viewRooms
* Renaming: The fields to access school classes in Role
            are now unified makes the resulting lens useful
            (it is a Traversal actually).
* New: Action.getSpacesForCurrentUser
* New: Persistent.Pure.getSpacesForRole