### PR TITLE
Paths & Queries

### DIFF
--- a/src/Data/UriPath.hs
+++ b/src/Data/UriPath.hs
@@ -61,7 +61,7 @@ addHash (SlashFreeUriPart s) = SlashFreeUriPart ("#" <> s)
 (DiffUriParts ps q) </?> q' = DiffUriParts ps (q' : q)
 
 instance IsString UriPath where
-    fromString s = DiffUriParts (ps ++) []  -- TODO: why is this `++` not captured by hlint?
+    fromString s = DiffUriParts (ps <>) []
         where ps = SlashFreeUriPart <$> ST.splitOn "/" (cs s)
 
 relativeUriPath :: UriPath -> ST

--- a/src/Data/UriPath.hs
+++ b/src/Data/UriPath.hs
@@ -46,6 +46,7 @@ instance Monoid UriPath where
 
 infixl 7 </>
 infixl 7 </#>
+infixl 7 </?>
 
 (</>) :: UriPath -> UriPart -> UriPath
 DiffUriParts ps qs </> p = DiffUriParts (ps . (p :)) qs
@@ -56,8 +57,8 @@ ps </#> p = ps </> addHash p
 addHash :: UriPart -> UriPart
 addHash (SlashFreeUriPart s) = SlashFreeUriPart ("#" <> s)
 
-(</?>) :: UriPath -> HTTP.Query -> UriPath
-(DiffUriParts ps q) </?> q' = DiffUriParts ps (q <> q')
+(</?>) :: UriPath -> HTTP.QueryItem -> UriPath
+(DiffUriParts ps q) </?> q' = DiffUriParts ps (q' : q)
 
 instance IsString UriPath where
     fromString s = DiffUriParts (ps ++) []  -- TODO: why is this `++` not captured by hlint?

--- a/src/Data/UriPath.hs
+++ b/src/Data/UriPath.hs
@@ -9,6 +9,7 @@ module Data.UriPath
     , UriPath
     , (</>)
     , (</#>)
+    , (</?>)
     , absoluteUriPath
     , relativeUriPath
     , HasPath(..)
@@ -19,6 +20,8 @@ import Thentos.Prelude
 import Data.String.Conversions
 
 import qualified Data.Text as ST
+import qualified Network.HTTP.Types as HTTP
+
 
 newtype UriPart = SlashFreeUriPart { unUriPart :: ST }
 
@@ -31,18 +34,21 @@ instance s ~ ST => ConvertibleStrings UriPart s where
     convertString = unUriPart
 
 -- | An @UriPath@ is a list of @UriPart@s stored as a difference list.
-newtype UriPath = DiffUriParts { appendUriParts :: [UriPart] -> [UriPart] }
+data UriPath = DiffUriParts
+    { appendUriParts    :: [UriPart] -> [UriPart]
+    , diffUriPartsQuery :: HTTP.Query
+    }
 
 instance Monoid UriPath where
-    mempty = DiffUriParts id
+    mempty = DiffUriParts id []
 
-    DiffUriParts ps `mappend` DiffUriParts qs = DiffUriParts (ps . qs)
+    DiffUriParts ps q  `mappend` DiffUriParts ps' q' = DiffUriParts (ps . ps') (q <> q')
 
 infixl 7 </>
 infixl 7 </#>
 
 (</>) :: UriPath -> UriPart -> UriPath
-DiffUriParts ps </> p = DiffUriParts (ps . (p :))
+DiffUriParts ps qs </> p = DiffUriParts (ps . (p :)) qs
 
 (</#>) :: UriPath -> UriPart -> UriPath
 ps </#> p = ps </> addHash p
@@ -50,12 +56,18 @@ ps </#> p = ps </> addHash p
 addHash :: UriPart -> UriPart
 addHash (SlashFreeUriPart s) = SlashFreeUriPart ("#" <> s)
 
+(</?>) :: UriPath -> HTTP.Query -> UriPath
+(DiffUriParts ps q) </?> q' = DiffUriParts ps (q <> q')
+
 instance IsString UriPath where
-    fromString s = DiffUriParts (ps ++)
+    fromString s = DiffUriParts (ps ++) []  -- TODO: why is this `++` not captured by hlint?
         where ps = SlashFreeUriPart <$> ST.splitOn "/" (cs s)
 
 relativeUriPath :: UriPath -> ST
-relativeUriPath u = ST.intercalate "/" . map cs $ u `appendUriParts` []
+relativeUriPath u = p <> q
+  where
+    p = ST.intercalate "/" . map cs $ u `appendUriParts` []
+    q = cs . HTTP.renderQuery True . diffUriPartsQuery $ u
 
 absoluteUriPath :: UriPath -> ST
 absoluteUriPath u = "/" <> relativeUriPath u

--- a/src/EventLog.hs
+++ b/src/EventLog.hs
@@ -103,8 +103,11 @@ instance CSV.ToRecord URLEventLogItem where
 
         objLink' :: Either3 Topic Idea Comment -> U.Main
         objLink' (Left3   t) = U.listTopicIdeas t
-        objLink' (Middle3 i) = U.IdeaPath (i ^. ideaLocation) (U.ViewIdea (i ^. _Id))
-        objLink' (Right3 _c) = U.Broken
+        objLink' (Middle3 i) = U.IdeaPath (i ^. ideaLocation) (U.ViewIdea (i ^. _Id) Nothing)
+        objLink' (Right3  c) = U.IdeaPath iloc (U.ViewIdea iid (Just $ c ^. _Id))
+          where
+            iloc = c ^. _Key . ckIdeaLocation
+            iid = c ^. _Key . ckIdeaId
 
         f (EventLogUserCreates obj) = CSV.toRecord
             [ "legt " <> objDesc obj <> " an.", objLink obj ]

--- a/src/Frontend/Fragment/IdeaList.hs
+++ b/src/Frontend/Fragment/IdeaList.hs
@@ -60,7 +60,7 @@ instance ToHtml ListItemIdea where
             when (IdeaInViewTopic == whatListPage) $ do
                 feasibilityVerdict False idea caps
 
-            a_ [href_ $ U.viewIdea idea] $ do
+            a_ [href_ $ U.viewIdea idea Nothing] $ do
                 -- FIXME use the phase
                 div_ [class_ "col-8-12"] $ do
                     div_ [class_ "ideas-list-img-container"] $ avatarImgFromHasMeta idea

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -549,13 +549,12 @@ instance FormPage PageAdminSettingsEventsProtocol where
     type FormPageResult PageAdminSettingsEventsProtocol = EventsProtocolFilter
 
     formAction (PageAdminSettingsEventsProtocol _) = U.Admin U.AdminEvent
-    redirectOf _ (EventsProtocolFilter Nothing)      = U.Admin U.AdminDlEvents
-    redirectOf _ (EventsProtocolFilter (Just space)) = U.Admin (U.AdminDlEventsF space)
+    redirectOf _ (EventsProtocolFilter mspace)     = U.Admin (U.AdminDlEvents mspace)
 
     makeForm (PageAdminSettingsEventsProtocol spaces) = EventsProtocolFilter <$> ("space" .: DF.choice vs Nothing)
       where
         vs :: [(Maybe IdeaSpace, Html ())]
-        vs = (Nothing, "(Alle Ideenräume)") : ((Just &&& toHtml . showIdeaSpaceUI) <$> spaces)
+        vs = (Nothing, "(Alle Ideenräume)") : ((Just &&& toHtml . toUrlPiece) <$> spaces)
 
     formPage v form p@(PageAdminSettingsEventsProtocol _) = adminFrame p . semanticDiv p . form $ do
         label_ $ do

--- a/src/Frontend/Page/Idea.hs
+++ b/src/Frontend/Page/Idea.hs
@@ -10,13 +10,13 @@ module Frontend.Page.Idea
   ( ViewIdea(..)
   , CreateIdea(..)
   , EditIdea(..)
-  , CommentIdea(..)
+  , CommentIdea(..)   -- FIXME: rename to 'CommentOnIdea'
   , JudgeIdea(..)
   , viewIdea
   , createIdea
   , editIdea
-  , commentIdea
-  , replyCommentIdea
+  , commentIdea       -- FIXME: rename to 'commentOnIdea'
+  , replyCommentIdea  -- FIXME: rename to 'commentOnComment'
   , judgeIdea
   )
 where
@@ -156,49 +156,6 @@ instance ToHtml ViewIdea where
                 toHtml $ IdeaVoteLikeBars caps p
 
             feasibilityVerdict True idea caps
-
-            when False . div_ $ do
-                -- FIXME: needs design/layout
-                -- FIXME: the forms have the desired effect, but they do not trigger a re-load.
-                -- this can probably be fixed with a simple click-handler (thanks, @np!).
-                div_ ">>>>>>>>>>> some phase-specific stuff"
-
-                postLink_ [] (U.likeIdea idea)         "like this idea"
-                postLink_ [] (U.voteIdea idea Yes)     "vote yes on idea"
-                postLink_ [] (U.voteIdea idea No)      "vote no on idea"
-                postLink_ [] (U.voteIdea idea Neutral) "vote neutral on idea"
-
-                pre_ . toHtml $ ppShow (idea ^. ideaLikes)
-                pre_ . toHtml $ ppShow (idea ^. ideaVotes)
-
-                div_ ">>>>>>>>>>> some phase-specific stuff"
-
-            {- FIXME: data model is not clear yet.  read process specs again!
-
-            div_ [class_ "heroic-badges"] $ do
-                case idea ^. ideaResult of
-                    NotFeasible _reason -> do
-                        div_ [class_ "m-not-feasable"] $ do
-                        i_ [class_ "icon-times"] nil
-                        "vom Direktor abgelehnt"
-                        -- FIXME display the _reason (do we? shall we?)
-                when (winningIdea idea) $ do
-                    div_ [class_ "m-feasable"] $ do
-                        i_ [class_ "icon-check"] nil
-                        ""
-
-            -}
-
-            -- visual vote stats
-            {- FIXME plug this in to my nice widget pls
-            when (phase >= Just PhaseVoting) . div_ [id_ "votes-stats"] . pre_ $ do
-                let y = countIdeaVotes Yes $ idea ^. ideaVotes
-                    n = countIdeaVotes No  $ idea ^. ideaVotes
-                div_ $ do
-                    span_ . toHtml $ "    " <> replicate y '+' <> ":" <> replicate n '-'
-                div_ $ do
-                    span_ . toHtml $ replicate (4 + y - length (show y)) ' ' <> show y <> ":" <> show n
-            -}
 
         -- article
         div_ [class_ "container-narrow text-markdown"] $ do

--- a/src/Frontend/Page/Idea.hs
+++ b/src/Frontend/Page/Idea.hs
@@ -252,7 +252,7 @@ instance FormPage CreateIdea where
 
     formAction (CreateIdea loc) = U.createIdea loc
 
-    redirectOf (CreateIdea _loc) = U.viewIdea
+    redirectOf (CreateIdea _loc) idea = U.viewIdea idea Nothing
 
     makeForm (CreateIdea loc) =
         ProtoIdea
@@ -268,7 +268,7 @@ instance FormPage EditIdea where
 
     formAction (EditIdea idea) = U.editIdea idea
 
-    redirectOf (EditIdea idea) _ = U.viewIdea idea
+    redirectOf (EditIdea idea) _ = U.viewIdea idea Nothing
 
     makeForm (EditIdea idea) =
         ProtoIdea
@@ -316,7 +316,7 @@ instance FormPage CommentIdea where
 
     formAction (CommentIdea idea mcomment) = U.commentOrReplyIdea idea mcomment
 
-    redirectOf (CommentIdea idea _) _ = U.viewIdea idea
+    redirectOf (CommentIdea idea _) = U.viewIdea idea . Just . view _Id
 
     makeForm CommentIdea{} =
         "comment-text" .: (Markdown <$> DF.text Nothing)

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -100,7 +100,6 @@ isPostOnly = \case
     -- FIXME[#312] Logout -> True
     _ -> False
 
--- FIXME: fix & remove
 isBroken :: Main -> Bool
 isBroken Broken = True
 isBroken _      = False
@@ -138,8 +137,8 @@ data Space =
 
 instance SOP.Generic Space
 
-viewIdea :: Idea -> Main
-viewIdea idea = IdeaPath (idea ^. ideaLocation) $ ViewIdea (idea ^. _Id)
+viewIdea :: Idea -> Maybe (AUID Comment) -> Main
+viewIdea idea manchor = IdeaPath (idea ^. ideaLocation) (ViewIdea (idea ^. _Id) manchor)
 
 editIdea :: Idea -> Main
 editIdea idea = IdeaPath (idea ^. ideaLocation) $ EditIdea (idea ^. _Id)
@@ -191,7 +190,8 @@ listTopicIdeas topic = listIdeas $ IdeaLocationTopic (topic ^. topicIdeaSpace) (
 
 ideaMode :: IdeaMode -> UriPath -> UriPath
 ideaMode ListIdeas         root = root </> "ideas"
-ideaMode (ViewIdea i)      root = root </> "idea" </> uriPart i </> "view"
+ideaMode (ViewIdea i mc)   root = maybe id (flip (</#>) . anchor) mc $
+                                  root </> "idea" </> uriPart i </> "view"
 ideaMode (EditIdea i)      root = root </> "idea" </> uriPart i </> "edit"
 ideaMode (LikeIdea i)      root = root </> "idea" </> uriPart i </> "like"
 ideaMode (VoteIdea i v)    root = root </> "idea" </> uriPart i </> "vote"
@@ -304,7 +304,7 @@ instance SOP.Generic CommentMode
 data IdeaMode =
       ListIdeas
     | CreateIdea
-    | ViewIdea (AUID Idea)
+    | ViewIdea (AUID Idea) (Maybe (AUID Comment))
     | EditIdea (AUID Idea)
     | LikeIdea (AUID Idea)
     | VoteIdea (AUID Idea) IdeaVoteValue

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -157,7 +157,7 @@ commentIdea :: Idea -> Main
 commentIdea idea = IdeaPath (idea ^. ideaLocation) $ CommentIdea (idea ^. _Id)
 
 onComment :: Comment -> CommentMode -> Main
-onComment comment = IdeaPath (ck ^. ckIdeaLocation) .  OnComment ck
+onComment comment = IdeaPath (ck ^. ckIdeaLocation) . OnComment ck
   where ck = comment ^. _Key
 
 replyComment :: Comment -> Main
@@ -199,7 +199,7 @@ ideaMode (VoteIdea i v)    root = root </> "idea" </> uriPart i </> "vote"
 ideaMode (JudgeIdea i v)   root = root </> "idea" </> uriPart i </> "jury"
                                        </> uriPart v
 ideaMode (CommentIdea i)   root = root </> "idea" </> uriPart i </> "comment"
-ideaMode (OnComment ck m) root = commentMode ck m root
+ideaMode (OnComment ck m)  root = commentMode ck m root
 ideaMode CreateIdea        root = root </> "idea" </> "create"
 
 anchor :: IsString s => AUID a -> s
@@ -220,9 +220,9 @@ commentMode (CommentKey _loc i parents commentId) m root =
     -- and replying up to depth 1.
     base n =
         case take n (parents <> [commentId]) of
-            [p]   -> root </> "idea" </> uriPart i </> "comment" </> uriPart p
-            [p,c] -> root </> "idea" </> uriPart i </> "comment" </> uriPart p </> "reply" </> uriPart c
-            _     -> error $ "Frontend.Path.commentMode.base " <> show n <> ": IMPOSSIBLE"
+            [p]    -> root </> "idea" </> uriPart i </> "comment" </> uriPart p
+            [p, c] -> root </> "idea" </> uriPart i </> "comment" </> uriPart p </> "reply" </> uriPart c
+            _      -> error $ "Frontend.Path.commentMode.base " <> show n <> ": IMPOSSIBLE"
 
 ideaPath :: IdeaLocation -> IdeaMode -> UriPath -> UriPath
 ideaPath loc mode root =

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -38,6 +38,7 @@ where
 import GHC.Generics
 import Thentos.Prelude
 import Data.UriPath
+import Servant.API (toUrlPiece)
 
 import qualified Generics.SOP as SOP
 
@@ -270,8 +271,7 @@ data AdminMode =
   | AdminViewClasses
   | AdminEvent
   | AdminDlPass SchoolClass
-  | AdminDlEvents
-  | AdminDlEventsF IdeaSpace
+  | AdminDlEvents (Maybe IdeaSpace)
   deriving (Generic, Show)
 
 instance SOP.Generic AdminMode
@@ -288,8 +288,8 @@ admin AdminCreateClass      path = path </> "class" </> "create"
 admin (AdminEditClass clss) path = path </> "class" </> uriPart clss </> "edit"
 admin AdminEvent            path = path </> "event"
 admin (AdminDlPass clss)    path = path </> "downloads" </> "passwords" </> uriPart clss
-admin AdminDlEvents         path = path </> "downloads" </> "events"
-admin (AdminDlEventsF spc)  path = path </> "downloads" </> "events" </> uriPart spc
+admin (AdminDlEvents mspc)  path = path </> "downloads" </> "events"
+                                   </?> ("space", cs . toUrlPiece <$> mspc)
 
 data CommentMode
     = ReplyComment

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -815,22 +815,22 @@ instance Binary Quorums
 instance Binary Settings
 
 makePrisms ''AUID
-makePrisms ''IdeaLocation
 makePrisms ''Category
+makePrisms ''DelegationContext
 makePrisms ''Document
-makePrisms ''IdeaVoteValue
+makePrisms ''EmailAddress
 makePrisms ''IdeaJuryResultValue
-makePrisms ''IdeaVoteResultValue
-makePrisms ''UpDown
+makePrisms ''IdeaLocation
 makePrisms ''IdeaSpace
+makePrisms ''IdeaVoteResultValue
+makePrisms ''IdeaVoteValue
 makePrisms ''Phase
 makePrisms ''Role
-makePrisms ''UserPass
-makePrisms ''DelegationContext
-makePrisms ''EmailAddress
-makePrisms ''UserLastName
+makePrisms ''UpDown
 makePrisms ''UserFirstName
+makePrisms ''UserLastName
 makePrisms ''UserLogin
+makePrisms ''UserPass
 makePrisms ''UserView
 
 makeLenses ''Category
@@ -846,35 +846,35 @@ makeLenses ''Document
 makeLenses ''Durations
 makeLenses ''EditTopicData
 makeLenses ''EditUserData
+makeLenses ''EmailAddress
+makeLenses ''GMetaInfo
 makeLenses ''Idea
-makeLenses ''IdeaLocation
-makeLenses ''IdeaLike
 makeLenses ''IdeaJuryResult
-makeLenses ''IdeaVoteResult
-makeLenses ''IdeaVoteLikeKey
+makeLenses ''IdeaLike
+makeLenses ''IdeaLocation
 makeLenses ''IdeaSpace
 makeLenses ''IdeaVote
-makeLenses ''GMetaInfo
+makeLenses ''IdeaVoteLikeKey
+makeLenses ''IdeaVoteResult
 makeLenses ''Phase
-makeLenses ''UserProfile
 makeLenses ''ProtoDelegation
 makeLenses ''ProtoIdea
 makeLenses ''ProtoTopic
 makeLenses ''ProtoUser
+makeLenses ''Quorums
 makeLenses ''Role
 makeLenses ''SchoolClass
 makeLenses ''Settings
 makeLenses ''Topic
 makeLenses ''UpDown
 makeLenses ''User
-makeLenses ''UserView
-makeLenses ''EmailAddress
-makeLenses ''UserLogin
 makeLenses ''UserFirstName
 makeLenses ''UserLastName
+makeLenses ''UserLogin
 makeLenses ''UserPass
+makeLenses ''UserProfile
 makeLenses ''UserSettings
-makeLenses ''Quorums
+makeLenses ''UserView
 
 deriveSafeCopy 0 'base ''AUID
 deriveSafeCopy 0 'base ''Category
@@ -884,31 +884,30 @@ deriveSafeCopy 0 'base ''CommentVote
 deriveSafeCopy 0 'base ''CommentVoteKey
 deriveSafeCopy 0 'base ''Delegation
 deriveSafeCopy 0 'base ''DelegationContext
--- deriveSafeCopy 0 'base ''DelegationNetwork
+deriveSafeCopy 0 'base ''DelegationNetwork
 deriveSafeCopy 0 'base ''Document
 deriveSafeCopy 0 'base ''DurationDays
 deriveSafeCopy 0 'base ''Durations
 deriveSafeCopy 0 'base ''EditTopicData
 deriveSafeCopy 0 'base ''EditUserData
+deriveSafeCopy 0 'base ''GMetaInfo
 deriveSafeCopy 0 'base ''Idea
-deriveSafeCopy 0 'base ''IdeaVoteLikeKey
+deriveSafeCopy 0 'base ''IdeaJuryResult
+deriveSafeCopy 0 'base ''IdeaJuryResultValue
 deriveSafeCopy 0 'base ''IdeaLike
 deriveSafeCopy 0 'base ''IdeaLocation
--- deriveSafeCopy 0 'base ''IdeaLike
-deriveSafeCopy 0 'base ''IdeaJuryResult
-deriveSafeCopy 0 'base ''IdeaVoteResult
-deriveSafeCopy 0 'base ''IdeaJuryResultValue
-deriveSafeCopy 0 'base ''IdeaVoteResultValue
 deriveSafeCopy 0 'base ''IdeaSpace
 deriveSafeCopy 0 'base ''IdeaVote
+deriveSafeCopy 0 'base ''IdeaVoteLikeKey
+deriveSafeCopy 0 'base ''IdeaVoteResult
+deriveSafeCopy 0 'base ''IdeaVoteResultValue
 deriveSafeCopy 0 'base ''IdeaVoteValue
-deriveSafeCopy 0 'base ''GMetaInfo
 deriveSafeCopy 0 'base ''Phase
 deriveSafeCopy 0 'base ''ProtoDelegation
 deriveSafeCopy 0 'base ''ProtoIdea
 deriveSafeCopy 0 'base ''ProtoTopic
 deriveSafeCopy 0 'base ''ProtoUser
-deriveSafeCopy 0 'base ''UserProfile
+deriveSafeCopy 0 'base ''Quorums
 deriveSafeCopy 0 'base ''Role
 deriveSafeCopy 0 'base ''SchoolClass
 deriveSafeCopy 0 'base ''Settings
@@ -916,12 +915,12 @@ deriveSafeCopy 0 'base ''Timestamp
 deriveSafeCopy 0 'base ''Topic
 deriveSafeCopy 0 'base ''UpDown
 deriveSafeCopy 0 'base ''User
-deriveSafeCopy 0 'base ''UserLogin
 deriveSafeCopy 0 'base ''UserFirstName
 deriveSafeCopy 0 'base ''UserLastName
+deriveSafeCopy 0 'base ''UserLogin
 deriveSafeCopy 0 'base ''UserPass
+deriveSafeCopy 0 'base ''UserProfile
 deriveSafeCopy 0 'base ''UserSettings
-deriveSafeCopy 0 'base ''Quorums
 
 class Ord (IdOf a) => HasMetaInfo a where
     metaInfo        :: Lens' a (MetaInfo a)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1075,6 +1075,9 @@ parseSchoolClass s = case ST.splitOn "-" s of
 instance FromHttpApiData IdeaSpace where
     parseUrlPiece = parseIdeaSpace
 
+instance ToHttpApiData IdeaSpace where
+    toUrlPiece = cs . showIdeaSpace
+
 instance FromHttpApiData SchoolClass where
     parseUrlPiece = parseSchoolClass
 

--- a/tests/Frontend/Page/AdminSpec.hs
+++ b/tests/Frontend/Page/AdminSpec.hs
@@ -21,20 +21,23 @@ spec = do
         let shouldHaveHeaders = bodyShouldContain $
               intercalate ("," :: String) eventLogItemCsvHeaders
 
-        context "unfiltered" . it "works" $ \wreq -> do
+        context "unfiltered" . it "responds with data" $ \wreq -> do
             get wreq "/admin/downloads/events"
                 `shouldRespond` [codeShouldBe 200, shouldHaveHeaders]
 
-        context "filtered on existing idea space" . it "works" $ \wreq -> do
-            get wreq "/admin/downloads/events/school"
+        context "filtered on existing idea space" . it "responds with data" $ \wreq -> do
+            get wreq "/admin/downloads/events?space=school"
                 `shouldRespond` [codeShouldBe 200, shouldHaveHeaders]
 
-        context "filtered on non-existent idea space" . it "works" $ \wreq -> do
-            get wreq "/admin/downloads/events/2016-980917"
+        context "filtered on non-existent idea space" . it "responds with empty" $ \wreq -> do
+            get wreq "/admin/downloads/events?space=2016-980917"
                 `shouldRespond` [codeShouldBe 200, bodyShouldBe "[Keine Daten]"]
+                -- (it would be nicer to respond with 404 here, but nothing bad should happen with
+                -- the status quo either, and as long as the admin uses the UI, this shouldn't ever
+                -- happen.)
 
-        context "filtered with bad idea space identifier" . it "works" $ \wreq -> do
-            get wreq "/admin/downloads/events/no-such-space"
-                `shouldRespond` [codeShouldBe 404]
+        context "filtered with bad idea space identifier" . it "responds with 404" $ \wreq -> do
+            get wreq "/admin/downloads/events?space=no-such-space"
+                `shouldRespond` [codeShouldBe 500]
 
-        -- FIXME: test empty event log.
+        -- missing test: test empty event log.


### PR DESCRIPTION
More exhaustive support for uri queries and hashes in `Data.UriPath`, `Frontend.Path`.

Fixes #31, improves usability of buttons vote/comment/report, and resolves this:

```haskell
-- [Frontend.hs]
  :<|> adminEventLogCsv . Just  -- FIXME: with QueryParam, we could melt these two routes into one.
                                -- this isn't a hard task, but we need to extend 'UriPath' type.
```
