### PR TITLE
More expressive types for phase timespans.

### DIFF
--- a/src/Action.hs
+++ b/src/Action.hs
@@ -384,7 +384,9 @@ createIdea :: Create Idea
 createIdea = currentUserAddDb AddIdea
 
 createTopic :: Create Topic
-createTopic = currentUserAddDb AddTopic
+createTopic proto = do
+    now <- getCurrentTimestamp
+    currentUserAddDb (AddTopic now) proto
 
 
 -- * Vote Handling

--- a/src/DemoData.hs
+++ b/src/DemoData.hs
@@ -195,9 +195,11 @@ universe rnd = do
     avatars   <- generate numberOfStudents rnd genAvatar
     zipWithM_ updateAvatar students avatars
 
-    topics  <- mapM (currentUserAddDb AddTopic) =<< generate numberOfTopics rnd (genTopic ideaSpaces)
+    topics <- mapM (currentUserAddDb (AddTopic constantSampleTimestamp ))
+                =<< generate numberOfTopics rnd (genTopic ideaSpaces)
 
-    ideas  <- mapM (currentUserAddDb AddIdea) =<< generate numberOfIdeas rnd (genIdea ideaSpaces topics)
+    ideas <- mapM (currentUserAddDb AddIdea)
+                =<< generate numberOfIdeas rnd (genIdea ideaSpaces topics)
 
     sequence_ =<< generate numberOfLikes rnd (genLike ideas students)
 
@@ -277,7 +279,7 @@ genInitialTestDb = do
             , _protoIdeaLocation = IdeaLocationSpace SchoolSpace
             })
 
-    topic <- update $ AddTopic (EnvWith user1 constantSampleTimestamp ProtoTopic
+    topic <- update $ AddTopic constantSampleTimestamp (EnvWith user1 constantSampleTimestamp ProtoTopic
         { _protoTopicTitle       = "topic-title"
         , _protoTopicDesc        = Markdown "topic-desc"
         , _protoTopicImage       = ""

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -305,7 +305,7 @@ adminQuorum =
         (PageAdminSettingsQuorum <$> query (view dbQuorums))
         (\qs -> do
             update $ SaveQuorums qs
-            addMessage "Die neue Werte wurden gespeichert.")
+            addMessage "Die neuen Werte wurden gespeichert.")
 
 
 -- ** Freeze
@@ -331,7 +331,7 @@ instance FormPage PageAdminSettingsFreeze where
             li_ "Es kann nicht mehr auf Kommentare abgestimmt werden."
 
         label_ [class_ "input-append"] $ do
-            span_ [class_ "label-text"] "Aktueller status"
+            span_ [class_ "label-text"] "Aktueller Status"
             DF.inputSelect "freeze" v
         DF.inputSubmit "Status setzen!"
 

--- a/src/LifeCycle.hs
+++ b/src/LifeCycle.hs
@@ -22,7 +22,6 @@ where
 
 import Control.Lens
 import Data.Monoid
-import Data.Time
 import GHC.Generics (Generic)
 import qualified Generics.SOP as SOP
 
@@ -67,15 +66,15 @@ phaseTrans PhaseVoting{} VotingPhaseSetbackToJuryPhase
 -- an exception for these because that would require to handle this
 -- case in other places where it is less convenient, I think.)
 phaseTrans PhaseRefinement{_refPhaseEnd} (PhaseFreeze now)
-    = Just (PhaseRefFrozen {_refPhaseLeftover = realToFrac $ unTimestamp _refPhaseEnd `diffUTCTime` unTimestamp now}, [])
+    = Just (PhaseRefFrozen {_refPhaseLeftover = _refPhaseEnd `diffTimestamps` now}, [])
 phaseTrans PhaseRefFrozen{_refPhaseLeftover} (PhaseThaw now)
-    = Just (PhaseRefinement {_refPhaseEnd = Timestamp $ realToFrac _refPhaseLeftover `addUTCTime` unTimestamp now}, [])
+    = Just (PhaseRefinement {_refPhaseEnd = _refPhaseLeftover `addTimespan` now}, [])
 phaseTrans PhaseJury PhaseFreeze{} = Just (PhaseJury, [])
 phaseTrans PhaseJury PhaseThaw{} = Just (PhaseJury, [])
 phaseTrans PhaseVoting{_votPhaseEnd} (PhaseFreeze now)
-    = Just (PhaseVotFrozen {_votPhaseLeftover = realToFrac $ unTimestamp _votPhaseEnd `diffUTCTime` unTimestamp now}, [])
+    = Just (PhaseVotFrozen {_votPhaseLeftover = _votPhaseEnd `diffTimestamps` now}, [])
 phaseTrans PhaseVotFrozen{_votPhaseLeftover} (PhaseThaw now)
-    = Just (PhaseVoting {_votPhaseEnd = Timestamp $ realToFrac _votPhaseLeftover `addUTCTime` unTimestamp now}, [])
+    = Just (PhaseVoting {_votPhaseEnd = _votPhaseLeftover `addTimespan` now}, [])
 phaseTrans PhaseResult PhaseFreeze{} = Just (PhaseResult, [])
 phaseTrans PhaseResult PhaseThaw{} = Just (PhaseResult, [])
 -- Others considered invalid (throw an error later on).

--- a/src/Persistent/Pure.hs
+++ b/src/Persistent/Pure.hs
@@ -121,6 +121,7 @@ module Persistent.Pure
     )
 where
 
+import Control.Exception (assert)
 import Control.Lens
 import Control.Monad.Except (MonadError, ExceptT(ExceptT), runExceptT, throwError)
 import Control.Monad.Reader (MonadReader, runReader, asks)
@@ -145,6 +146,7 @@ import qualified Data.Set  as Set
 import qualified Data.Text as ST
 
 import Types
+import qualified LifeCycle
 
 
 -- * state type
@@ -463,14 +465,15 @@ moveIdeasToLocation ideaIds location =
 setTopicPhase :: AUID Topic -> Phase -> AUpdate ()
 setTopicPhase tid phase = modifyTopic tid $ topicPhase .~ phase
 
-addTopic :: AddDb Topic
-addTopic pt = do
+addTopic :: Timestamp -> AddDb Topic
+addTopic now pt = do
     t <- addDb dbTopicMap pt
     dbFrozen <- liftAQuery $ view dbFreeze
-    -- FIXME: the invariant that topics start in Ref phases is now spread
-    -- across a couple of different places. To merge it, or when it no longer
-    -- holds, use the full @phaseChange@ machinery (requiring @now@, etc.).
-    when (dbFrozen == Frozen) $ setTopicPhase (t ^. _Id) (PhaseRefFrozen 0)
+    when (dbFrozen == Frozen) $ do
+        case LifeCycle.phaseTrans (t ^. topicPhase) (LifeCycle.PhaseFreeze now) of
+            Just (phase'@(PhaseRefFrozen _), [])
+                -> setTopicPhase (t ^. _Id) phase'
+            bad -> assert False . error $ "addTopic: internal error: " <> show bad
     -- (failure to match the following can only be caused by an inconsistent state)
     Just topic <- liftAQuery $ findTopic (t ^. _Id)
     -- FIXME a new topic should not be able to steal ideas from other topics of course the UI will

--- a/tests/Persistent/ApiSpec.hs
+++ b/tests/Persistent/ApiSpec.hs
@@ -9,6 +9,7 @@
 
 module Persistent.ApiSpec where
 
+import Control.Exception (assert)
 import Control.Lens hiding (elements)
 import Control.Monad.IO.Class
 import Control.Monad.Reader
@@ -178,7 +179,7 @@ persistApiSpec imp = do
     addDbSpec imp "addUsers" getAllUsers AddUser
 
     getDbSpec imp "getTopics" getTopics
-    addDbSpec imp "addTopics" getTopics AddTopic
+    addDbSpec imp "addTopics" getTopics (AddTopic (assert False $ error "(no current time for freezing)"))
 
     findInBySpec imp "findUserByLogin" getAllUsers findUserByLogin userLogin ("not" <>)
     findInBySpec imp "findTopic" getTopics findTopic _Id changeAUID


### PR DESCRIPTION
Fixes 2 issues with creating frozen topics:
- see FIXME;
- the leftover time was set to 0 instead of the configured maximum.