### PR TITLE
Add make rule for git-grep.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,6 @@ content:
 
 tags: .phony
 	hasktags -b src/ tests/ exec/ dist/build/autogen/
+
+grep.%:
+	git grep -Hni $*


### PR DESCRIPTION
Introduces the shell syntax `make grep.TODO`.
I use this for my strange emacs setup.