### PR TITLE
Shifting phases

### DIFF
--- a/src/Action.hs
+++ b/src/Action.hs
@@ -600,7 +600,6 @@ topicInVotingResetToJury tid = do
 
 -- * Admin activities
 
--- | Make a topic timeout if the timeout is applicable.
 -- FIXME: Only admin can do that
 topicForceNextPhase :: (ActionM m) => AUID Topic -> m ()
 topicForceNextPhase tid = do

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -624,7 +624,6 @@ topicForcePreviousPhase tid = do
         PhaseResult       -> topicPhaseChange topic RevertResultPhaseToVoting
 
 -- TODO: make user errors more interesting action exceptions and report them on the UI.
--- TODO: explain what shifting phases does in the UI.  steal documentation from freeze page.  WARN!!
 
 
 -- * files

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -359,7 +359,7 @@ aulaAdmin =
   :<|> Page.adminInitialPasswordsCsv
   :<|> adminEventLogCsv
   :<|> Action.topicForceNextPhase
-  :<|> Action.topicInVotingResetToJury
+  :<|> Action.topicForcePreviousPhase
   :<|> form Page.adminPhaseChange
 
 

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -808,13 +808,13 @@ data PhaseChangeDir = Forward | Backward
 
 instance SOP.Generic PhaseChangeDir
 
-phaseChangeDirText :: PhaseChangeDir -> ST
-phaseChangeDirText Forward  = "vorwärts"
-phaseChangeDirText Backward = "zurück"
+instance HasUILabel PhaseChangeDir where
+    uilabel Forward  = "vorwärts"
+    uilabel Backward = "zurück"
 
 instance ToHtml PhaseChangeDir where
     toHtmlRaw = toHtml
-    toHtml    = toHtml . phaseChangeDirText
+    toHtml    = toHtml . uilabelST
 
 data AdminPhaseChangeForTopicData = AdminPhaseChangeForTopicData (AUID Topic) PhaseChangeDir
   deriving (Eq, Show)

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -360,8 +360,8 @@ adminFreeze =
              update $ SaveAndEnactFreeze now payload)
         (\_ f _ ->
             case f of
-                Frozen    -> "Das System wurde re-aktiviert (Normalbetrieb)." :: ST
-                NotFrozen -> "Das System wurde eingefroren (Ferienbetrieb).")
+                Frozen    -> "Das System wurde eingefroren (Ferienbetrieb)." :: ST
+                NotFrozen -> "Das System wurde re-aktiviert (Normalbetrieb).")
 
 
 -- ** roles and permisisons

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -791,7 +791,7 @@ adminPhaseChange =
         (\(AdminPhaseChangeForTopicData tid dir) -> do
             case dir of
                 Forward -> Action.topicForceNextPhase tid
-                Backward -> Action.topicInVotingResetToJury tid
+                Backward -> Action.topicForcePreviousPhase tid
         )
         (\AdminPhaseChange (AdminPhaseChangeForTopicData tid _dir) () -> do
             topic <- Action.mquery $ findTopic tid

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -797,7 +797,7 @@ adminPhaseChange =
             topic <- Action.mquery $ findTopic tid
             return $ unwords
                 [ "Das Thema wurde in Phase"
-                , topic ^. topicPhase . to show
+                , topic ^. topicPhase . uilabeled
                 , "verschoben."
                 ]
         )

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -793,7 +793,7 @@ adminPhaseChange =
                 Forward -> Action.topicForceNextPhase tid
                 Backward -> Action.topicInVotingResetToJury tid
         )
-        (\_ (AdminPhaseChangeForTopicData tid _) _ -> do
+        (\AdminPhaseChange (AdminPhaseChangeForTopicData tid _dir) () -> do
             topic <- Action.mquery $ findTopic tid
             return $ unwords
                 [ "Das Thema wurde in Phase"

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -819,7 +819,7 @@ instance ToHtml PhaseChangeDir where
 data AdminPhaseChangeForTopicData = AdminPhaseChangeForTopicData (AUID Topic) PhaseChangeDir
   deriving (Eq, Show)
 
--- FIXME: if we keep this, there needs to be some sort of feedback to the admin what happened with
+-- TODO: if we keep this, there needs to be some sort of feedback to the admin what happened with
 -- the phase change.  we could redirect to a page showing a message of the form "topic with title
 -- ... and id ... changed from phase ... to phase ...".  or we could add a message queue to the
 -- session state that gets flushed and appended to the digestive functors errors implicitly whenever
@@ -843,6 +843,13 @@ instance FormPage AdminPhaseChange where
     formPage v form p = adminFrame p . semanticDiv p $ do
         h3_ "Phasen verschieben"
         form $ do
+            div_ [class_ "container-info"] $ do
+                p_ "ACHTUNG!  GEFAHR!"
+                ul_ $ do
+                    li_ "Diese Seite erlaubt es, Themen in beide Richtungen (Zukunft und Vergangenheit) zu verschieben."
+                    li_ "Dies ist ein experimentelles Feature, und kann zu unerwartetem Verhalten führen.  Bitte nur mit"
+                    li_ "gutem Grund und nur nach Rücksprache mit den zuständigen Moderatoren durchführen!"
+
             div_ $ do
                 p_ "ID-Nummer der Themas aus der URL"
                 DF.inputText "topic-id" v

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -40,7 +40,7 @@ import Persistent.Api
     )
 import Persistent
     ( dbDurations, dbQuorums, dbFreeze, loginIsAvailable, getUserViews, getSchoolClasses
-    , findActiveUser, getUsersInClass, findActiveUser, getSpaces, findTopic, getUsersInClass
+    , findActiveUser, getUsersInClass, findActiveUser, getSpaces, getUsersInClass
     )
 import Frontend.Prelude
 import Frontend.Validation hiding (tab, spaces)
@@ -786,20 +786,12 @@ adminPhaseChange
     :: forall m . (ActionM m)
     => FormPageHandler m AdminPhaseChange
 adminPhaseChange =
-    formPageHandlerCalcMsgM
+    formPageHandler
         (pure AdminPhaseChange)
-        (\(AdminPhaseChangeForTopicData tid dir) -> do
+        (\(AdminPhaseChangeForTopicData tid dir) -> void $ do
             case dir of
                 Forward -> Action.topicForceNextPhase tid
                 Backward -> Action.topicForcePreviousPhase tid
-        )
-        (\AdminPhaseChange (AdminPhaseChangeForTopicData tid _dir) () -> do
-            topic <- Action.mquery $ findTopic tid
-            return $ unwords
-                [ "Das Thema wurde in Phase"
-                , topic ^. topicPhase . uilabeled
-                , "verschoben."
-                ]
         )
 
 
@@ -819,11 +811,6 @@ instance ToHtml PhaseChangeDir where
 data AdminPhaseChangeForTopicData = AdminPhaseChangeForTopicData (AUID Topic) PhaseChangeDir
   deriving (Eq, Show)
 
--- TODO: if we keep this, there needs to be some sort of feedback to the admin what happened with
--- the phase change.  we could redirect to a page showing a message of the form "topic with title
--- ... and id ... changed from phase ... to phase ...".  or we could add a message queue to the
--- session state that gets flushed and appended to the digestive functors errors implicitly whenever
--- we show a form.
 instance FormPage AdminPhaseChange where
     type FormPagePayload AdminPhaseChange = AdminPhaseChangeForTopicData
 

--- a/src/LifeCycle.hs
+++ b/src/LifeCycle.hs
@@ -36,7 +36,6 @@ import Types
 
 data PhaseChange
     = RefinementPhaseTimeOut
-    | RefinementPhaseMarkedByModerator
     | AllIdeasAreMarked { _phaseChangeVotPhaseEnd :: Timestamp }
     | VotingPhaseTimeOut
     | VotingPhaseSetbackToJuryPhase
@@ -69,8 +68,6 @@ thawPhase now = (phaseStatus     %~ thawStatus)
 
 phaseTrans :: Phase -> PhaseChange -> Maybe (Phase, [PhaseAction])
 phaseTrans (PhaseRefinement ActivePhase{}) RefinementPhaseTimeOut
-    = Just (PhaseJury, [JuryPhasePrincipalEmail])
-phaseTrans (PhaseRefinement ActivePhase{}) RefinementPhaseMarkedByModerator
     = Just (PhaseJury, [JuryPhasePrincipalEmail])
 phaseTrans PhaseJury (AllIdeasAreMarked {_phaseChangeVotPhaseEnd})
     = Just (PhaseVoting (ActivePhase _phaseChangeVotPhaseEnd), [])

--- a/src/LifeCycle.hs
+++ b/src/LifeCycle.hs
@@ -285,7 +285,7 @@ topicJuryCaps = \case
     SchoolGuest      -> []
     Moderator        -> []
     Principal        -> []
-    Admin            -> [CanPhaseForwardTopic]
+    Admin            -> [CanPhaseForwardTopic, CanPhaseBackwardTopic]
 
 topicVotingCaps :: Role -> [TopicCapability]
 topicVotingCaps = \case
@@ -303,4 +303,4 @@ topicResultCaps = \case
     SchoolGuest      -> []
     Moderator        -> []
     Principal        -> []
-    Admin            -> []
+    Admin            -> [CanPhaseBackwardTopic]

--- a/src/LifeCycle.hs
+++ b/src/LifeCycle.hs
@@ -76,11 +76,11 @@ phaseTrans PhaseJury (AllIdeasAreMarked {_phaseChangeVotPhaseEnd})
 phaseTrans (PhaseVoting ActivePhase{}) VotingPhaseTimeOut
     = Just (PhaseResult, [ResultPhaseModeratorEmail])
 phaseTrans (PhaseVoting ActivePhase{}) RevertJuryPhaseToRefinement
-    = Just (PhaseJury, [])  -- TODO: actions?
+    = Just (PhaseJury, [])
 phaseTrans (PhaseVoting ActivePhase{}) RevertVotingPhaseToJury
-    = Just (PhaseJury, [UnmarkAllIdeas])
+    = Just (PhaseJury, [])
 phaseTrans (PhaseVoting ActivePhase{}) RevertResultPhaseToVoting
-    = Just (PhaseJury, [])  -- TODO: actions?
+    = Just (PhaseJury, [])
 
 -- Freezing and thawing.
 --

--- a/tests/Frontend/CoreSpec.hs
+++ b/tests/Frontend/CoreSpec.hs
@@ -201,7 +201,7 @@ instance PayloadToEnv AdminPhaseChangeForTopicData where
         "topic-id" -> pure [TextInput $ cs (show tid)]
         "dir"      -> pure [TextInput $ selectValue "dir" v dirs dir]
       where
-        dirs = (id &&& cs . phaseChangeDirText) <$> [Forward, Backward]
+        dirs = (id &&& uilabel) <$> [Forward, Backward]
 
 instance PayloadToEnv IdeaJuryResultValue where
     payloadToEnvMapping _ r = \case


### PR DESCRIPTION
Fixes #472, but does more.

Most notably:
- we can now shift back through all phases from result to refinement
- jury statements are not removed any more when switching back to jury phase.  (i think this means that the next edit will trigger another phase shift.  we should think about this some more.)
