### PR TITLE
Type safety for paths

### DIFF
--- a/src/Action.hs
+++ b/src/Action.hs
@@ -131,7 +131,8 @@ import qualified Data.Vector as V
 
 import Action.Smtp
 import Config (Config, GetConfig(..), exposedUrl)
-import Data.UriPath (absoluteUriPath, relPath)
+import Data.UriPath (absoluteUriPath)
+import Frontend.Path (relPath)
 import LifeCycle
 import Logger
 import Logger.EventLog

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -778,11 +778,11 @@ arbMarkdownTable = pure nil
 
 -- * path
 
-instance Arbitrary P.Main where
+instance Arbitrary (P.Main r) where
     arbitrary = suchThat garbitrary (not . P.isBroken)
     shrink    = gshrink
 
-instance Arbitrary P.IdeaMode where
+instance Arbitrary (P.IdeaMode r) where
     arbitrary = prune <$> garbitrary
       where
         prune (P.OnComment ck P.ReplyToComment) = P.OnComment (pruneCommentKey ck) P.ReplyToComment
@@ -795,19 +795,19 @@ pruneCommentKey = \case
     ck@(CommentKey _ _ [] _) -> ck
     (CommentKey loc idea (c:_) c') -> CommentKey loc idea [c] c'
 
-instance Arbitrary P.CommentMode where
+instance Arbitrary (P.CommentMode r) where
     arbitrary = garbitrary
     shrink    = gshrink
 
-instance Arbitrary P.Space where
+instance Arbitrary (P.Space r) where
     arbitrary = garbitrary
     shrink    = gshrink
 
-instance Arbitrary P.UserMode where
+instance Arbitrary (P.UserMode r) where
     arbitrary = garbitrary
     shrink    = gshrink
 
-instance Arbitrary P.AdminMode where
+instance Arbitrary (P.AdminMode r) where
     arbitrary = garbitrary
     shrink    = gshrink
 

--- a/src/Data/UriPath.hs
+++ b/src/Data/UriPath.hs
@@ -12,7 +12,6 @@ module Data.UriPath
     , (</?>)
     , absoluteUriPath
     , relativeUriPath
-    , HasPath(..)
     , HasUriPart(..))
     where
 
@@ -79,9 +78,6 @@ relativeUriPath u = p <> q
 
 absoluteUriPath :: UriPath -> ST
 absoluteUriPath u = "/" <> relativeUriPath u
-
-class HasPath p where
-    relPath :: p -> UriPath
 
 class HasUriPart p where
     uriPart :: p -> UriPart

--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -110,7 +110,7 @@ aulaTop cfg app =
        (\req cont -> getSamplesPath >>= \path ->
           waiServeDirectory path req cont)
   :<|> waiServeDirectory (cfg ^. htmlStatic)
-  :<|> (redirect . absoluteUriPath . relPath $ U.ListSpaces)
+  :<|> (redirect . absoluteUriPath . U.relPath $ U.ListSpaces)
   :<|> app
   where
     waiServeDirectory :: FilePath -> Application
@@ -191,7 +191,7 @@ aulaMain =
   :<|> makeFrame (pure PageStaticTermsOfUse)
 
   :<|> form Page.login
-  :<|> (logout >> (redirect . absoluteUriPath . relPath $ U.Login))
+  :<|> (logout >> (redirect . absoluteUriPath . U.relPath $ U.Login))
 
 type CommentApi
        -- reply on a comment

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -289,7 +289,7 @@ class Page p => FormPage p where
     type FormPageResult p = ()
 
     -- | The form action used in form generation
-    formAction :: p -> P.Main
+    formAction :: p -> P.Main 'P.AllowGetPost
     -- | Calculates a redirect address from the given page.
     --
     -- Currently, 'FormPage' forces you to redirect after a form has been processed successfully.
@@ -305,7 +305,7 @@ class Page p => FormPage p where
     -- making impossible to not redirect one day.
     --
     -- Context: github #398, #83.
-    redirectOf :: p -> FormPageResult p -> P.Main
+    redirectOf :: p -> FormPageResult p -> P.Main 'P.AllowGetPost
     -- | Generates a Html view from the given page
     makeForm :: ActionM m => p -> DF.Form (Html ()) m (FormPagePayload p)
     -- | @formPage v f p@

--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -84,7 +84,8 @@ import qualified Text.Digestive.Lucid.Html5 as DF
 
 import Action
 import Config
-import Data.UriPath (HasPath(..), UriPath, absoluteUriPath)
+import Data.UriPath (UriPath, absoluteUriPath)
+import Frontend.Path (HasPath(..))
 import Lucid.Missing (script_, href_, src_, nbsp)
 import Types
 

--- a/src/Frontend/Page/Admin.hs
+++ b/src/Frontend/Page/Admin.hs
@@ -221,7 +221,7 @@ adminFrame t bdy = do
   where
     tab = toMenuItem [t]
 
-data MenuLink = MenuLink ST U.AdminMode ST
+data MenuLink = MenuLink ST (U.AdminMode 'U.AllowGetPost) ST
   deriving (Show)
 
 menulink :: Monad m => MenuItem -> MenuItem -> HtmlT m ()

--- a/src/Frontend/Page/Login.hs
+++ b/src/Frontend/Page/Login.hs
@@ -76,7 +76,7 @@ instance FormPage PageHomeWithLoginPrompt where
     guardPage _ = do
         -- Redirect from login if the user is already logged in.
         li <- Action.isLoggedIn
-        pure $ if li then Just $ relPath U.ListSpaces else Nothing
+        pure $ if li then Just $ U.relPath U.ListSpaces else Nothing
 
 
 instance ToHtml LoginDemoHints where

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -24,7 +24,7 @@
 module Frontend.Path
     ( HasPath(..)
     , Top(..)
-    , Allow(..)
+    , AllowedMethod(..)
     , Main(..)
     , Space(..)
     , IdeaMode(..)
@@ -100,15 +100,16 @@ import Types
 
 -- * types
 
-data Allow = AllowGetPost | AllowPost
+-- FIXME: Introduce AllowGet only
+data AllowedMethod = AllowGetPost | AllowPost
 
-class HasPath (p :: Allow -> *) where
+class HasPath (p :: AllowedMethod -> *) where
     relPath :: p r -> UriPath
 
 
 -- ** Top
 
-data Top (r :: Allow) =
+data Top (r :: AllowedMethod) =
     Top
   | TopMain (Main r)
   | TopTesting UriPath
@@ -130,7 +131,7 @@ top (TopStatic p)  = nil </> "static" <> p
 
 -- ** Main
 
-data Main (r :: Allow) =
+data Main (r :: AllowedMethod) =
     ListSpaces
   | Space IdeaSpace (Space r)
   | IdeaPath IdeaLocation (IdeaMode r)
@@ -178,7 +179,7 @@ ideaPath loc mode root =
 
 -- ** Space
 
-data Space (r :: Allow) =
+data Space (r :: AllowedMethod) =
     ListTopics
   | ListIdeasInSpace (Maybe IdeasQuery)
   | ListIdeasInTopic (AUID Topic) ListIdeasInTopicTab (Maybe IdeasQuery)
@@ -209,7 +210,7 @@ topicTab = \case
 
 -- ** IdeaMode
 
-data IdeaMode (r :: Allow) =
+data IdeaMode (r :: AllowedMethod) =
       CreateIdea
     | ViewIdea (AUID Idea) (Maybe (AUID Comment))
     | EditIdea (AUID Idea)
@@ -251,7 +252,7 @@ ideaMode (UnmarkIdeaAsWinner i) root = root </> "idea" </> uriPart i </> "revoke
 
 -- ** CommentMode
 
-data CommentMode (r :: Allow)
+data CommentMode (r :: AllowedMethod)
     = ReplyToComment
     | DeleteComment
     | ReportComment
@@ -292,7 +293,7 @@ onComment comment = IdeaPath (ck ^. ckIdeaLocation) . OnComment ck
 
 -- ** AdminMode
 
-data AdminMode (r :: Allow) =
+data AdminMode (r :: AllowedMethod) =
     AdminDuration
   | AdminQuorum
   | AdminFreeze
@@ -335,7 +336,7 @@ admin AdminChangePhase                path = path </> "change-phase"
 
 -- ** UserMode
 
-data UserMode (r :: Allow) =
+data UserMode (r :: AllowedMethod) =
     UserIdeas
   | UserDelegations
   deriving (Generic, Show)

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -20,7 +20,8 @@
 --
 -- Rule: always add (and expect) trailing slashes.
 module Frontend.Path
-    ( Top(..)
+    ( HasPath(..)
+    , Top(..)
     , Main(..)
     , Space(..)
     , IdeaMode(..)
@@ -95,6 +96,10 @@ import Types
 
 
 -- * types
+
+class HasPath p where
+    relPath :: p -> UriPath
+
 
 -- ** Top
 

--- a/src/Frontend/Path.hs
+++ b/src/Frontend/Path.hs
@@ -379,22 +379,22 @@ moveIdea idea = IdeaPath (idea ^. ideaLocation) $ MoveIdea (idea ^. _Id)
 commentOnIdea :: Idea -> Main 'AllowGetPost
 commentOnIdea idea = IdeaPath (idea ^. ideaLocation) $ CommentOnIdea (idea ^. _Id)
 
-likeIdea :: Idea -> Main 'AllowGetPost
+likeIdea :: Idea -> Main 'AllowPost
 likeIdea idea = IdeaPath (idea ^. ideaLocation) $ LikeIdea (idea ^. _Id)
 
 judgeIdea :: Idea -> IdeaJuryResultType -> Main 'AllowGetPost
 judgeIdea idea = IdeaPath (idea ^. ideaLocation) . JudgeIdea (idea ^. _Id)
 
-voteOnIdea :: Idea -> IdeaVoteValue -> Main 'AllowGetPost
+voteOnIdea :: Idea -> IdeaVoteValue -> Main 'AllowPost
 voteOnIdea idea = IdeaPath (idea ^. ideaLocation) . VoteOnIdea (idea ^. _Id)
 
-unvoteOnIdea :: Idea -> User -> Main 'AllowGetPost
+unvoteOnIdea :: Idea -> User -> Main 'AllowPost
 unvoteOnIdea idea u = IdeaPath (idea ^. ideaLocation) $ UnvoteOnIdea (idea ^. _Id) (u ^. _Id)
 
-markIdeaAsWinner :: Idea -> Main 'AllowGetPost
+markIdeaAsWinner :: Idea -> Main 'AllowPost
 markIdeaAsWinner idea = IdeaPath (idea ^. ideaLocation) $ MarkIdeaAsWinner (idea ^. _Id)
 
-unmarkIdeaAsWinner :: Idea -> Main 'AllowGetPost
+unmarkIdeaAsWinner :: Idea -> Main 'AllowPost
 unmarkIdeaAsWinner idea = IdeaPath (idea ^. ideaLocation) $ UnmarkIdeaAsWinner (idea ^. _Id)
 
 creatorStatement :: Idea -> Main 'AllowGetPost
@@ -429,13 +429,13 @@ listIdeas' loc Nothing mquery =
 replyToComment :: Comment -> Main 'AllowGetPost
 replyToComment comment = onComment comment ReplyToComment
 
-voteOnComment :: Comment -> UpDown -> Main 'AllowGetPost
+voteOnComment :: Comment -> UpDown -> Main 'AllowPost
 voteOnComment comment = onComment comment . VoteOnComment
 
 reportComment :: Comment -> Main 'AllowGetPost
 reportComment comment = onComment comment ReportComment
 
-deleteComment :: Comment -> Main 'AllowGetPost
+deleteComment :: Comment -> Main 'AllowPost
 deleteComment comment = onComment comment DeleteComment
 
 viewComment :: Comment -> Main 'AllowGetPost

--- a/src/Logger/EventLog.hs
+++ b/src/Logger/EventLog.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds             #-}
+{-# LANGUAGE DataKinds                   #-}
 {-# LANGUAGE DeriveGeneric               #-}
 {-# LANGUAGE FlexibleContexts            #-}
 {-# LANGUAGE FlexibleInstances           #-}
@@ -122,7 +123,7 @@ instance CSV.ToRecord (WithURL EventLogItemWarm) where
         objLink :: ContentWarm -> ST
         objLink = (domainUrl <>) . absoluteUriPath . relPath . objLink'
 
-        objLink' :: ContentWarm -> U.Main
+        objLink' :: ContentWarm -> U.Main 'AllowGetPost
         objLink' (Left3   t) = U.listIdeasInTopic t ListIdeasInTopicTabAll Nothing
         objLink' (Middle3 i) = U.viewIdea i
         objLink' (Right3  c) = U.viewIdeaAtComment' (c ^. _Key)

--- a/src/Lucid/Missing.hs
+++ b/src/Lucid/Missing.hs
@@ -113,12 +113,10 @@ formMethod_ meth attrs path =
                   , Lucid.action_ (absoluteUriPath (relPath path))
                   ] <> attrs
 
--- TODO
-postLink_ :: HasPath p => [Lucid.Attribute] -> p 'AllowGetPost -> ST -> Monad m => Lucid.HtmlT m ()
+postLink_ :: HasPath p => [Lucid.Attribute] -> p 'AllowPost -> ST -> Monad m => Lucid.HtmlT m ()
 postLink_ attrs path = formMethod_ "POST" [] path . inputSubmit_ attrs
 
--- TODO
-postButton_ :: (Monad m, HasPath p) => [Lucid.Attribute] -> p 'AllowGetPost -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
+postButton_ :: (Monad m, HasPath p) => [Lucid.Attribute] -> p 'AllowPost -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
 postButton_ attrs path = formMethod_ "POST" [] path . Lucid.button_ ([ type_ "submit" ] <> attrs)
 
 

--- a/src/Lucid/Missing.hs
+++ b/src/Lucid/Missing.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -97,25 +98,27 @@ inputSubmit_ attrs value = input_ $
     , value_ value
     ] <> attrs
 
-src_ :: HasPath p => p -> Lucid.Attribute
+src_ :: HasPath p => p 'AllowGetPost -> Lucid.Attribute
 src_ = Lucid.src_ . absoluteUriPath . relPath
 
-href_ :: HasPath p => p -> Lucid.Attribute
+href_ :: HasPath p => p 'AllowGetPost -> Lucid.Attribute
 href_ = Lucid.href_ . absoluteUriPath . relPath
 
-onclick_ :: HasPath p => p -> Lucid.Attribute
+onclick_ :: HasPath p => p 'AllowGetPost -> Lucid.Attribute
 onclick_ p = Lucid.onclick_ ("location.href='" <> absoluteUriPath (relPath p) <> "'")
 
-formMethod_ :: (Monad m, HasPath p) => ST -> [Lucid.Attribute] -> p -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
+formMethod_ :: (Monad m, HasPath p) => ST -> [Lucid.Attribute] -> p a -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
 formMethod_ meth attrs path =
     Lucid.form_ $ [ Lucid.method_ meth
                   , Lucid.action_ (absoluteUriPath (relPath path))
                   ] <> attrs
 
-postLink_ :: HasPath p => [Lucid.Attribute] -> p -> ST -> Monad m => Lucid.HtmlT m ()
+-- TODO
+postLink_ :: HasPath p => [Lucid.Attribute] -> p 'AllowGetPost -> ST -> Monad m => Lucid.HtmlT m ()
 postLink_ attrs path = formMethod_ "POST" [] path . inputSubmit_ attrs
 
-postButton_ :: (Monad m, HasPath p) => [Lucid.Attribute] -> p -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
+-- TODO
+postButton_ :: (Monad m, HasPath p) => [Lucid.Attribute] -> p 'AllowGetPost -> Lucid.HtmlT m () -> Lucid.HtmlT m ()
 postButton_ attrs path = formMethod_ "POST" [] path . Lucid.button_ ([ type_ "submit" ] <> attrs)
 
 

--- a/src/Lucid/Missing.hs
+++ b/src/Lucid/Missing.hs
@@ -36,6 +36,7 @@ import qualified Text.Digestive.View as DF
 import qualified Text.Digestive.Lucid.Html5 as DF
 
 import Data.UriPath
+import Frontend.Path
 
 
 -- | See also https://github.com/chrisdone/lucid/issues/30

--- a/tests/Frontend/CoreSpec.hs
+++ b/tests/Frontend/CoreSpec.hs
@@ -30,6 +30,7 @@ import Config
 import Frontend.Core
 import Frontend.Fragment.Comment
 import Frontend.Page
+import Frontend.Path (relPath)
 import Logger (nullLog)
 import Persistent.Idiom (listInfoForIdeaIt)
 import Types

--- a/tests/Frontend/Page/FileUploadSpec.hs
+++ b/tests/Frontend/Page/FileUploadSpec.hs
@@ -19,7 +19,7 @@ import qualified Frontend.Path as U
 
 fileUploadPath :: (IsString s) => String -> s
 fileUploadPath rest =
-    fromString $ (cs . absoluteUriPath . relPath $ U.Admin U.AdminCreateClass) <> rest
+    fromString $ (cs . absoluteUriPath . U.relPath $ U.Admin U.AdminCreateClass) <> rest
 
 spec :: Spec
 spec = describe "file upload" $ do

--- a/tests/Frontend/PathSpec.hs
+++ b/tests/Frontend/PathSpec.hs
@@ -92,13 +92,13 @@ spec = do
                     checkPathHandler g
 
   where
-    mainGen :: Gen Main
+    mainGen :: Gen (Main 'AllowGetPost)
     mainGen = arbitrary
 
-    formActionGens :: [(String, Gen Main)]
+    formActionGens :: [(String, Gen (Main 'AllowGetPost))]
     formActionGens = map (\(F g) -> (show (typeOf g), formAction <$> g)) forms
 
-    formRedirectGens :: [(String, Gen Main)]
+    formRedirectGens :: [(String, Gen (Main 'AllowGetPost))]
     formRedirectGens = map (\(F g) -> (show (typeOf g), redirectOf <$> g <*> arb)) forms
 
     forms :: [FormGen]


### PR DESCRIPTION
Smart constructors should be introduced for every path we use as to achieve the full type safeness. I would do that in a different PR to minimize the size of the lousy coupled changes.