### PR TITLE
Unwobble buttons

### DIFF
--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -600,6 +600,7 @@ runPostHandler mp mr = coreRunHandler (const mp) $ \_ _ -> UnsafePostResult <$> 
 
 -- * js glue
 
+-- | FUTUREWORK: this entire DSL should be moved into the internal mechanics of @postButton*_@.
 data JsCallback
     = JsReloadOnClick
     | JsReloadOnClickAnchor ST
@@ -613,7 +614,7 @@ onclickJs = \case
     (JsRedirectOnClick href)     -> hdl $ target "href" href
   where
     hdl :: ST -> Attribute
-    hdl = Lucid.onclick_ . ("reloadOnClick(" <>) . (<> ")")
+    hdl = Lucid.onclick_ . ("simplePost(" <>) . (<> ")")
 
     target :: ST -> ST -> ST
     target key val = "{" <> key <> ": " <> cs (show val) <> "}"

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -150,15 +150,28 @@ function toggleClass(el, cl) {
     }
 }
 
-var reloadDelayMs = 250;
+function httpReqAsync(method, url, callback)
+{
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function() {
+        if (xmlHttp.readyState == 4) {
+            if (xmlHttp.status >= 200 && xmlHttp.status < 300) {
+                callback(xmlHttp);
+            } else {
+                console.log("http error: dumping xml object.");
+                console.log(xmlHttp);
+                throw "http error.";
+            }
+        }
+    }
+    xmlHttp.open(method, url, true);
+    xmlHttp.send(null);
+}
 
 function reloadOnClick(target) {
     // NOTE: it would be nice to avoid reload, but this is not a hard
     // requirement any more.
-    // FIXME: this is a race condition: if we wait for 0 ms, the page
-    // will usually be reloaded before the POST request updating the
-    // score can be processed.
-    setTimeout(function() {
+    var successHandler = function() {
         if (target && target.hash) {
             document.location.hash = target.hash;
         }
@@ -166,7 +179,13 @@ function reloadOnClick(target) {
             document.location.href = target.href;
         }
         document.location.reload(true);
-    }, reloadDelayMs);
+    };
+
+    httpReqAsync("POST", event.currentTarget.parentElement.action, successHandler);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+    return false;
 }
 
 function createPageSample() {

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -168,15 +168,15 @@ function httpReqAsync(method, url, callback)
     xmlHttp.send(null);
 }
 
-function reloadOnClick(target) {
+function simplePost(whereToAfter) {
     // NOTE: it would be nice to avoid reload, but this is not a hard
     // requirement any more.
     var successHandler = function() {
-        if (target && target.hash) {
-            document.location.hash = target.hash;
+        if (whereToAfter && whereToAfter.hash) {
+            document.location.hash = whereToAfter.hash;
         }
-        if (target && target.href) {
-            document.location.href = target.href;
+        if (whereToAfter && whereToAfter.href) {
+            document.location.href = whereToAfter.href;
         }
         document.location.reload(true);
     };


### PR DESCRIPTION
Fixes #578.

This was surprisingly simple.  We now don't reload the page after a fixed timeout, but after the response on the POST has been received.