### PR TITLE
Scale and circle avatars

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Makefile -whitespace

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ docker-hpc:
 	cp -R /liqd/aula/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/hpc .
 
 team-avatars: .phony
-	rm -r team-avatars
+	-rm -r team-avatars
 	mkdir team-avatars
 	curl -o team-avatars/andorp https://avatars1.githubusercontent.com/u/3465327?v=3&s=400
 	curl -o team-avatars/fisx https://avatars2.githubusercontent.com/u/10210727?v=3&s=400

--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,15 @@ grep.%:
 docker-hpc:
 	./.travis/docker-build.sh 1000
 	cp -R /liqd/aula/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/hpc .
+
+team-avatars: .phony
+	rm -r team-avatars
+	mkdir team-avatars
+	curl -o team-avatars/andorp https://avatars1.githubusercontent.com/u/3465327?v=3&s=400
+	curl -o team-avatars/fisx https://avatars2.githubusercontent.com/u/10210727?v=3&s=400
+	curl -o team-avatars/np https://avatars3.githubusercontent.com/u/5548?v=3&s=400
+	curl -o team-avatars/rittermo https://avatars3.githubusercontent.com/u/15341015?v=3&s=400
+	curl -o team-avatars/localgrr https://avatars1.githubusercontent.com/u/701632?v=3&s=400
+	curl -o team-avatars/mikolaj https://avatars1.githubusercontent.com/u/281893?v=3&s=400
+	$(EXEC) runhaskell -j5 $(FULL_SOURCES) ./exec/ResizeAvatar.hs 300 100 64 32 -- ./team-avatars/andorp ./team-avatars/fisx ./team-avatars/localgrr ./team-avatars/mikolaj ./team-avatars/np ./team-avatars/rittermo
+	@echo "Open now your web browser on: file://$$PWD/avatars.html"

--- a/aula.cabal
+++ b/aula.cabal
@@ -134,6 +134,71 @@ library
       Paths_aula
   default-language: Haskell2010
 
+executable aula-avatars
+  main-is: ResizeAvatar.hs
+  hs-source-dirs:
+      exec
+  ghc-options: -Wall
+  build-depends:
+      base >=4.8 && <4.9
+    , thentos-core >=0.5.0
+    , aeson
+    , aeson-pretty
+    , aeson-qq
+    , acid-state >=0.14
+    , basic-sop
+    , binary
+    , bytestring
+    , case-insensitive
+    , cassava >= 0.4.5.0
+    , containers
+    , cookie
+    , css-syntax
+    , digestive-functors
+    , digestive-functors-lucid
+    , directory
+    , elocrypt >=0.4.1 && <0.5
+    , email-validate
+    , filepath
+    , functor-infix
+    , generic-aeson
+    , generics-sop
+    , html-parse >= 0.1
+    , http-client
+    , http-media
+    , http-types
+    , JuicyPixels >=3.2.6.2 && <3.3
+    , lens
+    , lucid
+    , mime-mail
+    , mtl
+    , parsec
+    , pretty-show
+    , process
+    , QuickCheck
+    , quickcheck-instances
+    , safecopy
+    , scrypt
+    , servant
+    , servant-lucid
+    , servant-server
+    , stm
+    , string-conversions
+    , template-haskell
+    , text
+    , time
+    , transformers
+    , vector ==0.10.12.3
+    , wai
+    , wai-app-static
+    , warp
+    , yaml
+    , aula
+  other-modules:
+      Aula
+      RenderHtml
+  default-language: Haskell2010
+
 executable aula-html-dummies
   main-is: RenderHtml.hs
   hs-source-dirs:
@@ -199,6 +264,7 @@ executable aula-html-dummies
     , hspec
   other-modules:
       Aula
+      ResizeAvatar
   default-language: Haskell2010
 
 executable aula-server
@@ -263,6 +329,7 @@ executable aula-server
     , aula
   other-modules:
       RenderHtml
+      ResizeAvatar
   default-language: Haskell2010
 
 test-suite spec
@@ -351,7 +418,6 @@ test-suite spec
       AulaTests.Stories.Interpreter.Action
       AulaTests.Stories.Tests
       AulaTests.StoriesSpec
-      BackendSpec
       Data.MarkdownSpec
       DelegationSpec
       Frontend.CoreSpec

--- a/exec/ResizeAvatar.hs
+++ b/exec/ResizeAvatar.hs
@@ -27,7 +27,7 @@ main = do
             Left err -> fail err
             Right pic ->
                 forM_ dims $ \dim -> do
-                    hPutStrLn stderr $ unwords ["Resizing to ", show dim]
+                    hPutStrLn stderr $ unwords ["Resizing to", show dim]
                     savePngImage (destName dim arg) (makeAvatar dim pic)
     renderToFile "avatars.html" . html_ $ do
         head_ . title_ $ "AuLA avatars"

--- a/exec/ResizeAvatar.hs
+++ b/exec/ResizeAvatar.hs
@@ -27,7 +27,7 @@ main = do
             Left err -> fail err
             Right pic ->
                 forM_ dims $ \dim -> do
-                    hPutStrLn stderr $ unwords ["Resizing to", show dim]
+                    hPutStrLn stderr $ unwords ["Resizing to ", show dim]
                     savePngImage (destName dim arg) (makeAvatar dim pic)
     renderToFile "avatars.html" . html_ $ do
         head_ . title_ $ "AuLA avatars"
@@ -42,8 +42,6 @@ main = do
                         td_ $ img_ [src_ (cs arg)]
                         forM_ dims $ \dim ->
                             td_ $ img_ [src_ (cs $ destName dim arg)]
-
-
   where
     readDim s
         | not (null s) && all isDigit s = pure $ read s

--- a/exec/ResizeAvatar.hs
+++ b/exec/ResizeAvatar.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Codec.Picture
+import Control.Monad
+import Data.Char
+import Data.String.Conversions (cs)
+import Lucid
+import System.Environment
+import System.Exit
+import System.FilePath
+import System.IO
+
+import Data.Avatar (makeAvatar)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    let (dims', imgs') = span (/= "--") args
+    when (null dims') $ usage "No dimensions"
+    when (null imgs') $ usage "Missing separator `--'"
+    let imgs = tail imgs'
+    when (null imgs) $ usage "No images"
+    dims <- mapM readDim dims'
+    forM_ imgs $ \arg -> do
+        hPutStrLn stderr arg
+        res <- readImage arg
+        case res of
+            Left err -> fail err
+            Right pic ->
+                forM_ dims $ \dim -> do
+                    hPutStrLn stderr $ unwords ["Resizing to", show dim]
+                    savePngImage (destName dim arg) (makeAvatar dim pic)
+    renderToFile "avatars.html" . html_ $ do
+        head_ . title_ $ "AuLA avatars"
+        body_ [style_ "background-color: #fdf6e3;"] $ do
+            table_ $ do
+                thead_ . tr_ $ do
+                    th_ $ toHtml ("Original" :: String)
+                    forM_ dims $ \dim ->
+                        th_ . toHtml . show $ dim
+                tbody_ . forM_ imgs $ \arg -> do
+                    tr_ $ do
+                        td_ $ img_ [src_ (cs arg)]
+                        forM_ dims $ \dim ->
+                            td_ $ img_ [src_ (cs $ destName dim arg)]
+
+
+  where
+    readDim s
+        | not (null s) && all isDigit s = pure $ read s
+        | otherwise                     = usage "Unexpected dimension"
+
+    usage msg = do
+        hPutStrLn stderr msg
+        hPutStrLn stderr "Usage: aula-avatars <dim>* -- <file>*"
+        exitFailure
+
+    destName dim arg = takeBaseName arg <.> "avatar" <.> show (dim :: Int) <.> "png"

--- a/package.yaml
+++ b/package.yaml
@@ -93,6 +93,13 @@ executables:
       - fsnotify
       - hspec
 
+  aula-avatars:
+    main: ResizeAvatar.hs
+    source-dirs: exec
+    other-modules:
+    dependencies:
+      - aula
+
 tests:
   spec:
     main: Spec.hs

--- a/src/Data/Avatar.hs
+++ b/src/Data/Avatar.hs
@@ -1,11 +1,28 @@
-{-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE ConstraintKinds    #-}
-module Data.Avatar (bilinear, resize, dynamicResize, dynamicPixelMap') where
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Data.Avatar
+    (-- * main
+      makeAvatar
+
+    -- unused
+    , dynamicResize
+
+    -- * internals
+    , resize
+    , bilinear
+    , dynamicPixelMap'
+    , scaleUp
+    , scaleDown
+    , dist
+    , clipCircle
+    , clipSquare) where
 
 import Codec.Picture
 import Codec.Picture.Types
-import Data.Word
 
 type IntegralPixel a = (Integral (PixelBaseComponent a), Pixel a)
 
@@ -15,11 +32,51 @@ bilinear p q r s u v = mixWith (f v) (mixWith (f u) p q) (mixWith (f u) r s)
   where
     f t _ x y = floor $ fromIntegral x * (1 - t) + fromIntegral y * t
 
+dist :: (Integral a, Floating d, p ~ (a, a)) => p -> p -> d
+dist (x0,y0) (x1,y1) = sqrt (sqr (x1 - x0) + sqr (y1 - y0))
+    where sqr x = fromIntegral x ^ (2 :: Int)
+
+clipSquare :: Pixel a => Image a -> Image a
+clipSquare img@(Image w h _) = generateImage f d d where
+    d = min w h
+    padx = (w - d) `div` 2
+    pady = (h - d) `div` 2
+    -- x in 0..w-1
+    -- y in 0..h-1
+    f x y = pixelAt img (padx + x) (pady + y)
+
+-- I must have missed something in JuicyPixels
+class Pixel a => ChangeOpacity a where
+    changeOpacity :: (PixelBaseComponent a -> PixelBaseComponent a) -> a -> a
+
+instance ChangeOpacity PixelRGBA16 where
+    changeOpacity f (PixelRGBA16 r g b a) = PixelRGBA16 r g b (f a)
+
+-- The `changeOpacity` opacity function takes an opacity value ranging from 0 to 1.
+clipCircle :: (ChangeOpacity a, Integral (PixelBaseComponent a), Bounded (PixelBaseComponent a))
+           => Image a -> Image a
+clipCircle img@(Image w h _) = generateImage f d d where
+    center = (w `div` 2, h `div` 2)
+    d = min w h
+    radius = d `div` 2 - max (d `div` 80) 2
+    -- x in 0..w-1
+    -- y in 0..h-1
+    f x y {-| inCircle x y = pixelAt img x y
+          | otherwise    =-}
+        = changeOpacity newOpacity (pixelAt img x y)
+      where
+        z = dist center (x, y) - fromIntegral radius
+        newOpacity old
+            | z < 0     = old
+            | otherwise = componentToLDR (1 / z ** 3)
+
 -- From: http://qiita.com/fumieval/items/2c761afb18e65c1fad06
-resize ::  IntegralPixel a => (Int, Int) -> Image a -> Image a
-resize (w, h) img@(Image w0 h0 _) = generateImage f w h where
-    f x y = let x' = fromIntegral x / fromIntegral w * fromIntegral w0
-                y' = fromIntegral y / fromIntegral h * fromIntegral h0
+scaleDown :: IntegralPixel a => (Int, Int) -> Image a -> Image a
+scaleDown (w, h) img@(Image w0 h0 _) = generateImage f w h where
+    -- x in 0..w-1
+    -- y in 0..h-1
+    f x y = let x' = min (fromIntegral $ w0 - 1) (fromIntegral x * fromIntegral w0 / fromIntegral w)
+                y' = min (fromIntegral $ h0 - 1) (fromIntegral y * fromIntegral h0 / fromIntegral h)
             in bilinear
                 (pixelAt img (floor x') (floor y'))
                 (pixelAt img (floor x' + 1) (floor y'))
@@ -28,9 +85,22 @@ resize (w, h) img@(Image w0 h0 _) = generateImage f w h where
                 (x' - fromInteger (floor x'))
                 (y' - fromInteger (floor y'))
 
+scaleUp :: Pixel a => (Int,Int) -> Image a -> Image a
+scaleUp (w, h) img@(Image w0 h0 _) = generateImage f w h where
+    f x y = let x' :: Float = fromIntegral x * fromIntegral w0 / fromIntegral w
+                y' :: Float = fromIntegral y * fromIntegral h0 / fromIntegral h
+            in pixelAt img (floor x') (floor y')
+
+resize :: IntegralPixel a => (Int, Int) -> Image a -> Image a
+resize (w, h) img@(Image w0 h0 _)
+    | w == w0 && h == h0 = img
+    | w >= w0 && h >= h0 = scaleUp (w, h) img
+    | w <= w0 && h <= h0 = scaleDown (w, h) img
+    | otherwise          = error $ unwords ["TODO unsupported resize:", show (w0, h0), "to", show (w, h)]
+
 -- From Codec.Picture.Saving
-componentToLDR :: Float -> Word8
-componentToLDR = truncate . (255 *) . min 1.0 . max 0.0
+componentToLDR :: forall a. (Integral a, Bounded a) => Float -> a
+componentToLDR = truncate . (fromIntegral (maxBound :: a) *) . min 1.0 . max 0.0
 
 -- From Codec.Picture.Saving
 toStandardDef :: Image PixelRGBF -> Image PixelRGB8
@@ -43,6 +113,9 @@ toStandardDef = pixelMap pixelConverter
 -- From Codec.Picture.Saving
 greyScaleToStandardDef :: Image PixelF -> Image Pixel8
 greyScaleToStandardDef = pixelMap componentToLDR
+
+makeAvatar :: Int -> DynamicImage -> DynamicImage
+makeAvatar d = ImageRGBA16 . clipCircle . resize (d,d) . clipSquare . convertImageToRGBA16
 
 dynamicResize :: (Int, Int) -> DynamicImage -> DynamicImage
 dynamicResize d = dynamicPixelMap' (resize d)
@@ -66,3 +139,21 @@ dynamicPixelMap' f = aux
     aux (ImageYCbCr8 i) = ImageYCbCr8 $ f i
     aux (ImageCMYK8  i) = ImageCMYK8  $ f i
     aux (ImageCMYK16 i) = ImageCMYK16 $ f i
+
+-- Derived from Codec.Picture.dynamicPixelMap, converting components with floats to 8bit
+-- using the same functions as Codec.Picture.Saving.imageToPng.
+convertImageToRGBA16 :: DynamicImage -> Image PixelRGBA16
+convertImageToRGBA16 = \case
+    ImageY8     i -> promoteImage (promoteImage i :: Image PixelRGBA8)
+    ImageY16    i -> promoteImage i
+    ImageYF     i -> promoteImage (toStandardDef (promoteImage i))
+    ImageYA8    i -> promoteImage (promoteImage i :: Image PixelRGBA8)
+    ImageYA16   i -> promoteImage i
+    ImageRGB8   i -> promoteImage i
+    ImageRGB16  i -> promoteImage i
+    ImageRGBF   i -> promoteImage (toStandardDef i)
+    ImageRGBA8  i -> promoteImage i
+    ImageRGBA16 i -> promoteImage i
+    ImageYCbCr8 i -> promoteImage (convertImage i :: Image PixelRGB8)
+    ImageCMYK8  i -> promoteImage (convertImage i :: Image PixelRGB8)
+    ImageCMYK16 i -> promoteImage (convertImage i :: Image PixelRGB16)

--- a/src/Frontend/Constant.hs
+++ b/src/Frontend/Constant.hs
@@ -29,3 +29,9 @@ maxPasswordLength = 120
 
 initialDemoPassword :: ST
 initialDemoPassword = "1234"
+
+avatarDefaultSize :: Int
+avatarDefaultSize = 100
+
+avatarExtraSizes :: [Int]
+avatarExtraSizes = [64, 300]

--- a/src/Frontend/Page/User.hs
+++ b/src/Frontend/Page/User.hs
@@ -17,6 +17,7 @@ import System.FilePath
 import Access
 import Action
 import Data.Avatar
+import Frontend.Constant (avatarDefaultSize, avatarExtraSizes)
 import Frontend.Fragment.DelegationTab
 import Frontend.Fragment.IdeaList
 import Frontend.Fragment.Note
@@ -371,16 +372,23 @@ editUserProfile uid = formPageHandlerWithMsg
                 throwError500 "IMPOSSIBLE: editUserProfile"
                 -- update . SetUserProfileDesc uid $ up ^. profileDesc
             Just file -> do
-                let dst = "static" </> "avatars" </> cs (uriPart uid) <.> "png"
-                    url = "/" <> dst
+                let dst dim = "static" </> "avatars" </> cs (uriPart uid) <> "-" <> show dim <.> "png"
+                    url dim = "/" <> dst dim
                 img <- readImageFile (cs file)
                 case img of
                     Left _e ->
                         -- FIXME: this should be dealt with the Nothing case.
                         -- throwError500 $ "image decoding failed: " <> e
                         update . SetUserProfileDesc uid $ up ^. profileDesc
-                    Right pic -> savePngImageFile dst (dynamicResize (53, 53) pic)
-                update . SetUserProfile uid $ up & profileAvatar ?~ cs url
+                    Right pic -> do
+                        forM_ (avatarDefaultSize : avatarExtraSizes) $ \dim -> savePngImageFile (dst dim) $ makeAvatar dim pic
+                -- There is no need to store this URL as long as it is determined only by the
+                -- user id & dimension. Therefor the profileAvatar field to be remove and
+                -- computed on the fly.
+                -- Moreover updating your profile picture is not changing this url so unless the
+                -- first time where it is empty.
+                --
+                update . SetUserProfile uid $ up & profileAvatar ?~ cs (url avatarDefaultSize)
     )
     "Die Änderungen wurden gespeichert."
 

--- a/src/Frontend/Page/User.hs
+++ b/src/Frontend/Page/User.hs
@@ -382,12 +382,9 @@ editUserProfile uid = formPageHandlerWithMsg
                         update . SetUserProfileDesc uid $ up ^. profileDesc
                     Right pic -> do
                         forM_ (avatarDefaultSize : avatarExtraSizes) $ \dim -> savePngImageFile (dst dim) $ makeAvatar dim pic
-                -- There is no need to store this URL as long as it is determined only by the
-                -- user id & dimension. Therefor the profileAvatar field to be remove and
-                -- computed on the fly.
-                -- Moreover updating your profile picture is not changing this url so unless the
-                -- first time where it is empty.
-                --
+                -- There is no need to store this URL as long as it is determined only by the user
+                -- id and dimension. Therefore the profileAvatar field could computed on the fly,
+                -- except for the 'Nothing' case (where we want to use a default profile picture.
                 update . SetUserProfile uid $ up & profileAvatar ?~ cs (url avatarDefaultSize)
     )
     "Die Änderungen wurden gespeichert."

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -610,7 +610,8 @@ followsPhase _               _                   = False
 -- * user
 
 data UserProfile = UserProfile
-    { _profileAvatar :: Maybe URL -- FIXME: This is a FilePath now
+    { _profileAvatar :: Maybe URL -- ^ FIXME: (1) This is a FilePath now; (2) do we want to keep
+                                  -- track of the stored sizes here?
     , _profileDesc   :: Document
     }
   deriving (Eq, Ord, Show, Read, Generic)


### PR DESCRIPTION
Fixes #598.  Fixes #436.

* Avatars are scaled up if needed and then clipped to circles.
* Add a new command aula-avatars which helps testing the avatars
  for a list of dimensions and files.
* Add avatarDefaultSize and avatarExtraSizes in Frontend.Constant.
* Uploading a new avatar now resizes to all these sizes.