### PR TITLE
Misc fixes.

### DIFF
--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -645,7 +645,7 @@ instance ToJSON JsSimplePost where
         conf = maybeToList $ ("askConfirm" Aeson..=) <$> mAskConfirm
 
 onclickJs :: JsSimplePost -> Attribute
-onclickJs = Lucid.onclick_ . ("simplePost(" <>) . (<> ")") . cs . Aeson.encode
+onclickJs = Lucid.onclick_ . ("simplePost(event, " <>) . (<> ")") . cs . Aeson.encode
 
 jsReloadOnClick :: Attribute
 jsReloadOnClick = onclickJs $ JsSimplePost JsSimplePostHere Nothing

--- a/src/Frontend/Page/Delegation.hs
+++ b/src/Frontend/Page/Delegation.hs
@@ -58,7 +58,7 @@ instance FormPage PageDelegateVote where
             "selected-delegate" .: DF.validate valid (DF.text (render <$> mselected))
       where
         render :: AUID User -> ST
-        render = cs . show . view unAUID
+        render = ("page-delegate-vote-uid." <>) . cs . show . view unAUID
 
         -- the error messages here are not translated because they shouldn't be user facing: the
         -- only causes for them are users messing with the page source and programming errors.

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -266,7 +266,7 @@
         // be slightly nicer to remember which nodes were invisible
         // and recover the state before the previous click on the root
         // node.)
-        var on_click = function(d) {
+        var on_click = function(clickee) {
             var newVisibilityStatus = undefined;
             var visited = [];
             var traverse = function(d) {
@@ -275,7 +275,12 @@
                 }
                 visited.push(d.name);
                 graph.links.forEach(function(l) {
-                    if (l.target.name === d.name) {
+                    // the target of the edge needs to be in the
+                    // sub-graph, but the source must not be the one
+                    // that we just clicked on: we don't want to close
+                    // the click-on node, or we won't be able to
+                    // re-open it.
+                    if (l.target.name === d.name && l.source.name !== clickee.name) {
                         if (newVisibilityStatus === undefined) {
                             newVisibilityStatus = !l.source.visible;
                         }
@@ -285,7 +290,7 @@
                 });
             };
 
-            traverse(d);
+            traverse(clickee);
             updateVisibility();
         };
 

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -266,7 +266,10 @@
         // be slightly nicer to remember which nodes were invisible
         // and recover the state before the previous click on the root
         // node.)
-        var on_click = function(clickee) {
+        var on_click = function(delegate) {
+            // the fun arg is the node that is clicked on.  it is
+            // called the delegate here because we process its
+            // delegatees.
             var newVisibilityStatus = undefined;
             var visited = [];
             var traverse = function(d) {
@@ -280,7 +283,7 @@
                     // that we just clicked on: we don't want to close
                     // the click-on node, or we won't be able to
                     // re-open it.
-                    if (l.target.name === d.name && l.source.name !== clickee.name) {
+                    if (l.target.name === d.name && l.source.name !== delegate.name) {
                         if (newVisibilityStatus === undefined) {
                             newVisibilityStatus = !l.source.visible;
                         }
@@ -290,7 +293,7 @@
                 });
             };
 
-            traverse(clickee);
+            traverse(delegate);
             updateVisibility();
         };
 

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -179,7 +179,7 @@ function httpReqAsync(method, url, callback)
     xmlHttp.send(null);
 }
 
-function simplePost(config) {
+function simplePost(event, config) {
     // NOTE: it would be nice to avoid reload, but this is not a hard
     // requirement any more.
 


### PR DESCRIPTION
Fixes the following unreported issues:

- delegate on user profile doesn't reload properly
- if you delegate to yourself and then close your node's delegatees in the graph, you close the node itself.
- delegate-to page behind topics, ideas: current delegation is rendered correctly (still not fixed: #728).
