### PR TITLE
Delegation network, again.

### DIFF
--- a/src/Persistent/Pure.hs
+++ b/src/Persistent/Pure.hs
@@ -157,7 +157,7 @@ import Control.Lens
 import Control.Monad.Except (MonadError, ExceptT(ExceptT), runExceptT, throwError)
 import Control.Monad.Reader (MonadReader, runReader, asks)
 import Control.Monad.State (MonadState, gets, put)
-import Control.Monad (foldM, unless, when, replicateM, forM)
+import Control.Monad (foldM, unless, when, replicateM, forM, filterM)
 import Data.Acid.Core
 import Data.Acid.Memory.Pure (Event(UpdateEvent))
 import Data.Acid (UpdateEvent, EventState, EventResult)
@@ -687,7 +687,7 @@ delegateesInScope delegate scope =
     <$> views dbDelegations (Data.Delegation.delegateesInScope delegate scope)
 
 votingPower :: AUID User -> DScope -> EQuery [User]
-votingPower uid scope = do
+votingPower uid scope = filter isActiveUser <$> do
     ancestors <- scopeAncestors scope
     catMaybes
         <$> (mapM findUser
@@ -706,10 +706,24 @@ scopeAncestors = \case
             IdeaLocationTopic _s t -> DScopeTopicId   t)
 
 findDelegationsByScope :: DScope -> Query (Map.Map (Delegate (AUID User)) [(DScope, Delegatee (AUID User))])
-findDelegationsByScope scope =
-    Map.fromList
-    <$> ((\(d,s,ds) -> (d, (,) s <$> ds))
-         <$$> views dbDelegations (Data.Delegation.findDelegationsByScope scope))
+findDelegationsByScope scope = do
+    delegs  <- views dbDelegations (Data.Delegation.findDelegationsByScope scope)
+    delegs' <- sequence $ f <$> delegs
+    pure . Map.fromList . catMaybes $ delegs'
+  where
+    f (d, s, ds) = do
+        yes <- isActiveDelegate d
+        if yes
+            then do
+                ds' <- filterM isActiveDelegatee ds
+                pure $ Just (d, (s,) <$> ds')
+            else pure Nothing
+
+isActiveDelegate :: Delegate (AUID User) -> Query Bool
+isActiveDelegate (Delegate u) = maybe False isActiveUser <$> findUser u
+
+isActiveDelegatee :: Delegatee (AUID User) -> Query Bool
+isActiveDelegatee (Delegatee u) = maybe False isActiveUser <$> findUser u
 
 findImplicitDelegationsByScope :: DScope -> EQuery (Map.Map (Delegate (AUID User)) [(DScope, Delegatee (AUID User))])
 findImplicitDelegationsByScope scope = do

--- a/src/Types/Instances/JSON.hs
+++ b/src/Types/Instances/JSON.hs
@@ -78,7 +78,7 @@ instance Aeson.ToJSON DelegationNetwork where
 
         renderNode (u, p) = Aeson.object
             [ "name"   Aeson..= (u ^. userLogin . unUserLogin)
-            , "avatar" Aeson..= (u ^. userAvatar avatarDefaultSize)
+            , "avatar" Aeson..= (u ^. userAvatar (minimum $ avatarDefaultSize : avatarExtraSizes))
             , "power"  Aeson..= p
             ]
 

--- a/src/Types/Instances/JSON.hs
+++ b/src/Types/Instances/JSON.hs
@@ -76,7 +76,6 @@ instance Aeson.ToJSON DelegationNetwork where
             , "links" Aeson..= array (renderLink <$> links)
             ]
 
-        -- FIXME: It shouldn't be rendered for deleted users.
         renderNode (u, p) = Aeson.object
             [ "name"   Aeson..= (u ^. userLogin . unUserLogin)
             , "avatar" Aeson..= (u ^. userAvatar avatarDefaultSize)

--- a/static/d3-aula.css
+++ b/static/d3-aula.css
@@ -1,6 +1,10 @@
 .node {
 }
 
+.has-hidden-edges {
+    opacity: 0.4;
+}
+
 .link {
     fill: none;
     stroke: black;

--- a/static/d3-aula.css
+++ b/static/d3-aula.css
@@ -2,23 +2,23 @@
 }
 
 .link {
-  fill: none;
-  stroke: black;
-  stroke-width: 2.5px;
+    fill: none;
+    stroke: black;
+    stroke-width: 2.5px;
 }
 
 .implicit {
-  stroke-dasharray: 5,5;
+    stroke-dasharray: 5,5;
 }
 
 .hidden {
-  opacity: 0;
+    opacity: 0;
 }
 
 text {
-  font: 16px sans-serif;
-  pointer-events: none;
-  text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
+    font: 16px sans-serif;
+    pointer-events: none;
+    text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
 }
 
 .svg-container {

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -345,7 +345,11 @@
         };
 
         var on_click = function(d) {
-            unfoldNeighbours(d, hasHiddenEdges(d), 1, 1);
+            if (hasHiddenEdges(d)) {
+                unfoldNeighbours(d, true, 1, 1);
+            } else {
+                unfoldNeighbours(d, false, -1, -1);
+            }
         };
 
         var on_mouseover = function(d) {

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -209,7 +209,7 @@
                 avat = container.append("g")
                     .selectAll("image").data(force.nodes())
                     .enter().append("image")
-                    .attr("class", ".node")
+                    .attr("class", function(d) { return "node" + (hasHiddenEdges(d) ? " has-hidden-edges" : ""); })
                     .call(force.drag)
                     .attr("width",  avatarWidthHeight.get)
                     .attr("height", avatarWidthHeight.get)
@@ -339,6 +339,14 @@
             updateVisibility();
         };
 
+        var hasHiddenEdges = function(d) {
+            var v = false;
+            var check = function(n) { if (!visible(n)) { v = true; }; };
+            d.delegates.forEach(check);
+            d.delegatees.forEach(check);
+            return v;
+        };
+
         var on_click = function(d) {
             unfoldNeighbours(d, undefined, 1, 1);
         };
@@ -422,8 +430,8 @@
         var avat = undefined;
         var text = undefined;
 
-        updateWidget();
         setNeighbours(graph);
+        updateWidget();
         force.start();
     };
 

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -26,7 +26,8 @@
                         var alloption = {
                             "children": dscopeix[parent].subtree.children,
                             "dscope": dscopeix[parent].subtree.dscope,
-                            "text": "*"
+                            "text": "[Delegation für alle Themen]"
+                                // FIXME: here we assume the aula-specific dscope hierarchy structure.
                         };
                         options.unshift(alloption);
                     }

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -311,9 +311,6 @@
             var visited = [];
 
             var updateVisible = function(n) {
-                if (show === undefined) {
-                    show = !visible(n);
-                }
                 n.visibleByClick = show;
                 // clicking overrides the other filters
                 if (show) {
@@ -348,7 +345,7 @@
         };
 
         var on_click = function(d) {
-            unfoldNeighbours(d, undefined, 1, 1);
+            unfoldNeighbours(d, hasHiddenEdges(d), 1, 1);
         };
 
         var on_mouseover = function(d) {

--- a/static/d3-aula.js
+++ b/static/d3-aula.js
@@ -375,13 +375,6 @@
             // d.fixed = false;  // (see comment in on_mouseover)
         };
 
-
-        // [initialization]
-
-        // tweak hints: width should depend on browser width; height
-        // should depend on total voting power of all nodes in scope.
-        var globalGraphWidth = 600;
-
         var visible = function(d) {
             return d.visibleByPower && d.visibleByMatching && d.visibleByClick;
         };
@@ -395,6 +388,12 @@
             d.visibleByMatching = true;
             d.visibleByClick = true;
         };
+
+
+        // [initialization]
+
+        // tweak hints: width should depend on browser width.
+        var globalGraphWidth = 600;
 
         graph.nodes.forEach(makeAllVisible);
 
@@ -417,7 +416,6 @@
                .attr("viewBox", "0 0 " + globalGraphWidth + " " + globalGraphWidth)
                // class to make it responsive
                .classed("svg-content-responsive", true);
-
 
         svg.append("defs")
             .selectAll("marker")


### PR DESCRIPTION
Fixes #827.  Fixes #825.

The user instructions have changed a bit again:

1. nodes that have hidden edges now look a little transparent so you know you have to click on them.  1. if you click on a node, all direct neighbours are toggled.  you have to keep clicking if you want to see more.
1. if you search for users, you only see matching nodes, but you can see by their transparency which ones to click on.
1. if you click on a node, all neighbors are made visible if and only if there is at least one invisible neighbor.  (before a click changed the visibility of all neighbors to the opposite of an arbitrary neighbor.)

i tried to unfold neighbors during the search, but it didn't work in the time box i had.