### PR TITLE
Gave ... menus a title #820

### DIFF
--- a/src/Frontend/Core.hs
+++ b/src/Frontend/Core.hs
@@ -810,7 +810,7 @@ headerMarkup mUser = header_ [class_ "main-header", id_ "main-header"] $ do
                     li_ $ a_ [href_ P.delegationView] "Beauftragungsnetzwerk"
 
                 div_ [class_ "main-header-user"] $ do
-                    div_ [class_ "pop-menu"] $ do
+                    div_ [class_ "pop-menu", title_ "Optionen"] $ do
                         -- FIXME: please add class m-selected to currently selected menu item
                         div_ [class_ "user-avatar"] $
                             userAvatarImg avatarDefaultSize `mapM_` mUser

--- a/src/Frontend/Fragment/ContextMenu.hs
+++ b/src/Frontend/Fragment/ContextMenu.hs
@@ -11,7 +11,7 @@ import Frontend.Prelude
 
 contextMenu :: Monad m => [(Bool, ST, HtmlT m ())] -> HtmlT m ()
 contextMenu (filter (view _1) -> entries) = do
-    nav_ [class_ "pop-menu m-dots detail-header-menu"] $ do
+    nav_ [class_ "pop-menu m-dots detail-header-menu", title_ "Optionen"] $ do
         ul_ [class_ "pop-menu-list"] $ do
             if null entries
                 then li_ [class_ "pop-menu-list-item"] "<Menü ist leer>"


### PR DESCRIPTION
I have ... menus a title so they are accessible now. I didnt change the text to "Optionen" I think this makes it hard to read 
![screenshot-localhost 8080 2016-07-21 13-07-00](https://cloud.githubusercontent.com/assets/701632/17020833/2e5aba28-4f44-11e6-864a-14c97379c598.png)

How should I proceed ?
