### PR TITLE
add `--recursive` to grab submodule code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in a shell:
 ```shell
 # install docker
 docker pull quay.io/liqd/aula
-git clone https://github.com/liqd/aula
+git clone --recursive https://github.com/liqd/aula
 cd aula
 ./docker/run.sh
 # now you are inside the container.


### PR DESCRIPTION
I was giving `aula` a test run and ran into empty submodules. 

This solved it.