### PR TITLE
Cache control: cache static content

### DIFF
--- a/src/Frontend.hs
+++ b/src/Frontend.hs
@@ -101,7 +101,7 @@ runFrontendWithLoggerAndPersist cfg log metrics rp = do
 
     runSettings settings
         . (if cfg ^. devMode then createPageSamples else id)
-        . disableCaching
+        . cacheControlHeader cacheHeadersCacheStatic
         . catchHttpErrors (cfg ^. devMode)
         . maybe id EKG.metrics (fst <$> metrics)
         . serve aulaTopProxy $ aulaTop cfg app

--- a/src/Frontend/Middleware.hs
+++ b/src/Frontend/Middleware.hs
@@ -92,15 +92,18 @@ createPageSamples app req = app req'
 -- * 501 Not Implemented
 disableCaching :: Middleware
 disableCaching app req cont = app req $
-    cont . if relevantMeth then addHeadersToResponse cacheHeaders else id
-  where
-    cacheHeaders =
+    cont . if cacheRelevantMethod (requestMethod req)
+        then addHeadersToResponse cacheHeadersNoCache
+        else id
+
+cacheHeadersNoCache :: ResponseHeaders
+cacheHeadersNoCache =
         [ ("Cache-Control", "no-cache, no-store, must-revalidate")
         , ("Expires", "0")
         ]
 
-    relevantMeth :: Bool
-    relevantMeth = requestMethod req `elem` ["GET", "HEAD"]
+cacheRelevantMethod :: Method -> Bool
+cacheRelevantMethod = (`elem` ["GET", "HEAD"])
 
 addHeadersToResponse ::  ResponseHeaders -> Response -> Response
 addHeadersToResponse extraHeaders resp = case resp of

--- a/src/Frontend/Middleware.hs
+++ b/src/Frontend/Middleware.hs
@@ -16,7 +16,6 @@ where
 import Control.Category ((.))
 import Control.Exception (assert)
 import Control.Monad.Reader (runReader)
-import Data.Maybe (listToMaybe)
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Internal (Response(ResponseFile, ResponseBuilder, ResponseStream, ResponseRaw))
@@ -102,12 +101,15 @@ cacheControlHeader policy app req cont = app req $
         else id
   where
     matchingPolicy :: Maybe ResponseHeaders
-    matchingPolicy = listToMaybe . catMaybes $ f <$> policy
+    matchingPolicy = firstJust $ f <$> policy
       where
         f (prefix, plc) =
             if prefix `ST.isPrefixOf` (("/" <>) . ST.intercalate "/" . pathInfo $ req)
                 then Just plc
                 else Nothing
+
+        firstJust :: [Maybe a] -> Maybe a
+        firstJust = join . find isJust
 
 cacheHeadersNoCache :: [(ST, ResponseHeaders)]
 cacheHeadersNoCache =

--- a/src/Persistent/Idiom.hs
+++ b/src/Persistent/Idiom.hs
@@ -116,6 +116,16 @@ ideaTopic idea = case idea ^. ideaLocation of
 ideaPhase :: Idea -> MQuery Phase
 ideaPhase = (view topicPhase <$$>) . ideaTopic
 
+-- | FIXME:
+--
+-- 1. this function is only called with predicates of the form @(PhaseConstructor ==)@, so the error
+--    message could be much more helpful if we used a type @Phase@ instead of @Phase -> Bool@ as a
+--    check.
+-- 2. naming convention (needs to be introduced in coding style): @check...@ does not crash if
+--    something goes wrong.  use @assert...@ for that.
+-- 3. the calls to this function have been witnessed to crash on demo systems, most likely due to
+--    the fact that admin-as-god can see buttons that trigger this.  this is nothing to worry about
+--    too much, but it's quite ugly conceptually.  admin-as-god is ugly.
 checkInPhase :: (Phase -> Bool) -> Idea -> Topic -> EQuery ()
 checkInPhase isPhase idea topic =
     unless (isPhase phase) $ throwError500 msg


### PR DESCRIPTION
```
$ curl -v http://localhost:8080/login > /dev/null 
[...]
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< Date: Mon, 22 Aug 2016 09:30:45 GMT
* Server Warp/3.2.7 is not blacklisted
< Server: Warp/3.2.7
< Cache-Control: no-cache, no-store, must-revalidate
< Expires: 0
< Set-Cookie: aula=1839822807284392500000; Path=/
< Content-Type: text/html;charset=utf-8
[...]

$ curl -v http://localhost:8080/static/d3-aula.css > /dev/null 
[...]
< HTTP/1.1 200 OK
< Last-Modified: Wed, 10 Aug 2016 12:22:11 GMT
< Content-Length: 618
< Accept-Ranges: bytes
< Date: Mon, 22 Aug 2016 09:30:48 GMT
* Server Warp/3.2.7 is not blacklisted
< Server: Warp/3.2.7
< Cache-Control: public
< Content-Type: text/css
< last-modified: Wed, 10 Aug 2016 12:22:11 GMT
[...]
```