### PR TITLE
Event log with deleted items.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ testxlsxclass:
 	rm -f cookie-jar
 
 tags: .phony
-	hasktags -b src/ tests/ exec/ dist/build/autogen/
+	hasktags -b src/ tests/ exec/
 
 grepi.%:
 	git grep -Hni $* src tests exec

--- a/aula.cabal
+++ b/aula.cabal
@@ -750,6 +750,7 @@ test-suite spec
     , wreq
     , webdriver
   other-modules:
+      ActionSpec
       AllModulesSpec
       AulaTests
       AulaTests.Stories.DSL

--- a/src/Arbitrary.hs
+++ b/src/Arbitrary.hs
@@ -1223,6 +1223,9 @@ fishAvatars = unsafePerformIO fishAvatarsIO
 
 -- * event log
 
+instance (Arbitrary a) => Arbitrary (Perhaps a) where
+  arbitrary = PerhapsYes <$> arbitrary
+
 instance Arbitrary EventLog where
     arbitrary = EventLog <$> arb <*> arbWord <*> nonEmpty
       where

--- a/src/Frontend/Constant.hs
+++ b/src/Frontend/Constant.hs
@@ -7,7 +7,7 @@ import Data.String.Conversions (ST)
 -- FIXME: Search for global constants
 
 topicDescMaxLength :: Int
-topicDescMaxLength = 120
+topicDescMaxLength = 800
 
 minElabPeriod :: Int
 minElabPeriod = 1

--- a/src/Logger/EventLog.hs
+++ b/src/Logger/EventLog.hs
@@ -51,21 +51,21 @@ data EventLogItem user topic idea comment =
   deriving (Eq, Show, Generic)
 
 data EventLogItemValue user topic idea comment =
-    EventLogUserCreates           (Either3 topic idea comment)
-  | EventLogUserEdits             (Either3 topic idea comment)
-  | EventLogUserMarksIdeaFeasible idea (Maybe IdeaJuryResultType)
-  | EventLogUserVotesOnIdea       idea (Maybe IdeaVoteValue)
-  | EventLogUserVotesOnComment    idea comment (Maybe comment) UpDown
+    EventLogUserCreates              (Either3 topic idea comment)
+  | EventLogUserEdits                (Either3 topic idea comment)
+  | EventLogUserMarksIdeaFeasible    idea (Maybe IdeaJuryResultType)
+  | EventLogUserVotesOnIdea          idea (Maybe IdeaVoteValue)
+  | EventLogUserVotesOnComment       idea comment (Maybe comment) UpDown
       -- FIXME: this should just be a comment key resp. comment, but following the type errors
       -- reveals some things that are not trivial to refactor.  the current situation is not very
       -- nice: the first comment is either the target (if a top-level comment) or the parent of the
       -- target; the second is either absent (for top-level comments) or the target.  this could be
       -- easier.
-  | EventLogUserDelegates         DScope user
-  | EventLogUserWithdrawsDelegation DScope user
-  | EventLogTopicNewPhase         topic Phase Phase
+  | EventLogUserDelegates            DScope user
+  | EventLogUserWithdrawsDelegation  DScope user
+  | EventLogTopicNewPhase            topic Phase Phase
   | EventLogIdeaNewLocation          idea (Maybe topic) (Maybe topic)
-  | EventLogIdeaReachesQuorum     idea
+  | EventLogIdeaReachesQuorum        idea
   deriving (Eq, Show, Generic)
 
 

--- a/tests/ActionSpec.hs
+++ b/tests/ActionSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE ViewPatterns         #-}
 
 {-# OPTIONS_GHC -Wall -Werror #-}
 
@@ -23,6 +22,7 @@ spec :: Spec
 spec = do
   describe "event log" $ do
     it "works" $ do
+      pendingWith "needs acid-state snapshot and log file to run."
       l :: EventLog <- runAction readEventLog
       (ST.length . cs . show $ l) `shouldNotBe` 0
 

--- a/tests/ActionSpec.hs
+++ b/tests/ActionSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE ViewPatterns         #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module ActionSpec where
+
+import           Control.Lens
+import           Control.Monad.Trans.Except
+import           Data.String.Conversions
+import qualified Data.Text as ST
+import           Test.Hspec
+
+import           Action.Implementation (Action, mkRunAction)
+import           AulaTests
+import           Config
+import           Logger.EventLog
+import           Persistent (withPersist)
+
+
+spec :: Spec
+spec = do
+  describe "event log" $ do
+    it "works" $ do
+      l :: EventLog <- runAction readEventLog
+      (ST.length . cs . show $ l) `shouldNotBe` 0
+
+
+runAction :: Action a -> IO a
+runAction action = withPersist cfg $ \rp -> do
+  let run' :: Action a -> ExceptT ServantErr IO a
+      Nat run' = mkRunAction (ActionEnv rp cfg noLog Nothing)
+
+      run :: Action a -> IO a
+      run a = runExceptT (run' a) >>= throwLeft
+
+      throwLeft :: Either ServantErr a -> IO a
+      throwLeft (Left e)  = throwIO . ErrorCall . show $ e
+      throwLeft (Right v) = pure v
+
+  run action
+  where
+    cfg :: Config
+    cfg = defaultConfig
+            & persist . persistenceImpl       .~ AcidStateOnDisk
+            & persist . dbPath                .~ "./issue-1030/state/AulaData/"
+            & logging . eventLogPath          .~ "./issue-1030/aula-events.json"
+
+    noLog :: SendLogMsg
+    noLog = SendLogMsg $ \_ -> pure ()


### PR DESCRIPTION
Fixes #1030.

Event log download was choking on ideas from deleted class rooms.  Now the event log contains a note "GELÖSCHT" ("DELETED") in those places.

Missing:

- [ ] make sure event log download does not block the database (it takes quite a few moments)
- [ ] test against all pilot schools
- [ ] compose anonymised test data for the `ActionSpec` test.
